### PR TITLE
fix(config): do not leak registry credentials in validation error

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,7 +115,7 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 		return nil, fmt.Errorf("neither CONFIG_DOCKERCONFIGJSON nor CONFIG_DOCKERCONFIGJSONPATH defined")
 	}
 	if c.DockerConfigJSON != "" && c.DockerConfigJSONPath != "" {
-		return nil, fmt.Errorf("cannot specify both CONFIG_DOCKERCONFIGJSON (%s) and CONFIG_DOCKERCONFIGJSONPATH (%s)", c.DockerConfigJSON, c.DockerConfigJSONPath)
+		return nil, fmt.Errorf("cannot specify both CONFIG_DOCKERCONFIGJSON and CONFIG_DOCKERCONFIGJSONPATH")
 	}
 
 	return c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_NewConfig_Validation(t *testing.T) {
+	const credential = `{"auths":{"registry.example.com":{"auth":"c3VwZXJzZWNyZXQ="}}}`
+
+	tests := []struct {
+		name        string
+		opts        []ConfigOption
+		wantErr     bool
+		forbidInErr []string
+	}{
+		{
+			"valid inline dockerConfigJSON should not error",
+			[]ConfigOption{
+				WithSecretNamespace("imagepullsecret-patcher"),
+				WithDockerConfigJSON(credential),
+			},
+			false,
+			nil,
+		},
+		{
+			"neither dockerConfigJSON nor dockerConfigJSONPath should error",
+			[]ConfigOption{
+				WithSecretNamespace("imagepullsecret-patcher"),
+			},
+			true,
+			nil,
+		},
+		{
+			"both dockerConfigJSON and dockerConfigJSONPath should error without leaking values",
+			[]ConfigOption{
+				WithSecretNamespace("imagepullsecret-patcher"),
+				WithDockerConfigJSON(credential),
+				WithDockerConfigJSONPath("/path/to/dockerconfig.json"),
+			},
+			true,
+			[]string{credential, "c3VwZXJzZWNyZXQ="},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			_, err := NewConfig(tt.opts...)
+
+			// Assert
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for _, forbidden := range tt.forbidInErr {
+				if err != nil && strings.Contains(err.Error(), forbidden) {
+					t.Errorf("NewConfig() error message leaks sensitive value %q: %v", forbidden, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/tamcore/imagepullsecret-patcher/internal/config"
 )
 
+const nsDefault = "default"
+
 var (
 	True  = true
 	False = false
@@ -47,13 +49,13 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: "default",
+						Name:      nsDefault,
+						Namespace: nsDefault,
 					},
 				},
 			},
@@ -65,13 +67,13 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: "default",
+						Name:      nsDefault,
+						Namespace: nsDefault,
 					},
 				},
 			},
@@ -83,7 +85,7 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 						Annotations: map[string]string{
 							"pborn.eu/imagepullsecret-patcher-exclude": "true",
 						},
@@ -91,8 +93,8 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 				},
 				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: "default",
+						Name:      nsDefault,
+						Namespace: nsDefault,
 					},
 				},
 			},
@@ -104,13 +106,13 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: "default",
+						Name:      nsDefault,
+						Namespace: nsDefault,
 						Annotations: map[string]string{
 							"pborn.eu/imagepullsecret-patcher-exclude": "true",
 						},
@@ -162,13 +164,13 @@ func Test_IsManagedSecret(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: "default",
+						Name:      nsDefault,
+						Namespace: nsDefault,
 						Annotations: map[string]string{
 							config.AnnotationManagedBy: config.AnnotationAppName,
 						},
@@ -182,12 +184,12 @@ func Test_IsManagedSecret(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 			},
@@ -198,7 +200,7 @@ func Test_IsManagedSecret(t *testing.T) {
 			args{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
+						Name: nsDefault,
 					},
 				},
 				&corev1.Secret{
@@ -232,7 +234,7 @@ func Test_HasAnnotation(t *testing.T) {
 			"No annotations present. Should be false.",
 			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
+					Name: nsDefault,
 				},
 			},
 			"foo",
@@ -243,7 +245,7 @@ func Test_HasAnnotation(t *testing.T) {
 			"Desired annotation present. Should be true.",
 			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
+					Name: nsDefault,
 					Annotations: map[string]string{
 						config.AnnotationManagedBy: config.AnnotationAppName,
 					},


### PR DESCRIPTION
## Summary
- The validation error in `config.NewConfig` interpolated the full `CONFIG_DOCKERCONFIGJSON` value (registry credentials) into the error message, which `cmd/main.go` logs on startup misconfiguration. The message is now value-free, matching the already-safe wording in `utils.GetDockerConfigJSON`.
- Adds the first unit tests for the `config` package (`Test_NewConfig_Validation`), including an assertion that validation errors never contain the credential value.
- Replaces the repeated `"default"` literal in `utils_test.go` with a constant to satisfy `goconst`.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [ ] CI workflows green (unit tests + lint + e2e)