### PR TITLE
fix(controller): ignore NotFound when fetching ServiceAccount

### DIFF
--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,10 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	serviceAccount := &corev1.ServiceAccount{}
 	err := r.Get(ctx, req.NamespacedName, serviceAccount)
 	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// ServiceAccount was deleted after the event was queued - nothing to do.
+			return ctrl.Result{}, nil
+		}
 		// Error reading the object - requeue the request.
 		log.Error(err, "Failed to get ServiceAccount")
 		return ctrl.Result{}, err

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -190,6 +190,29 @@ var _ = Describe("ServiceAccount Controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
+		It("should ignore a ServiceAccount that no longer exists", func() {
+			_, _, serviceAccountNN, secretNN := makeObjects("testns-deleted", "ghost", cfg.SecretName)
+
+			By("Reconciling a ServiceAccount that was never created")
+			serviceAccountReconciler := &ServiceAccountReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Config: cfg,
+			}
+			result, err := serviceAccountReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: serviceAccountNN,
+			})
+
+			By("Expecting no error and no requeue, as NotFound must be ignored")
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			By("Checking that no Secret was created")
+			foundSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, secretNN, foundSecret)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("should not reconcile the resource", func() {
 			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-2", "default", cfg.SecretName)
 


### PR DESCRIPTION
## Summary
- `ServiceAccountReconciler.Reconcile` returned NotFound errors from the initial Get as reconcile errors, causing pointless exponential requeues plus error-level log noise whenever a ServiceAccount was deleted after its event was queued.
- NotFound is now ignored (clean return), matching controller-runtime best practice.

## Test plan
- [x] New test: reconciling a nonexistent ServiceAccount returns nil error, empty result, and creates no secret
- [ ] CI workflows green (unit tests + lint + e2e)