### PR TITLE
fix(config): validate dockerconfigjson is valid JSON

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ limitations under the License.
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 
 	env "github.com/caitlinelfring/go-env-default"
@@ -116,6 +117,9 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 	}
 	if c.DockerConfigJSON != "" && c.DockerConfigJSONPath != "" {
 		return nil, fmt.Errorf("cannot specify both CONFIG_DOCKERCONFIGJSON and CONFIG_DOCKERCONFIGJSONPATH")
+	}
+	if c.DockerConfigJSON != "" && !json.Valid([]byte(c.DockerConfigJSON)) {
+		return nil, fmt.Errorf("CONFIG_DOCKERCONFIGJSON does not contain valid JSON")
 	}
 
 	return c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,24 @@ func Test_NewConfig_Validation(t *testing.T) {
 			true,
 			[]string{credential, "c3VwZXJzZWNyZXQ="},
 		},
+		{
+			"invalid JSON in dockerConfigJSON should error without leaking the value",
+			[]ConfigOption{
+				WithSecretNamespace("imagepullsecret-patcher"),
+				WithDockerConfigJSON(`{"auths":{"registry.example.com":`),
+			},
+			true,
+			[]string{`{"auths":{"registry.example.com":`},
+		},
+		{
+			"whitespace-only dockerConfigJSON should error",
+			[]ConfigOption{
+				WithSecretNamespace("imagepullsecret-patcher"),
+				WithDockerConfigJSON("   "),
+			},
+			true,
+			nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -298,6 +298,9 @@ func GetDockerConfigJSON(c *config.Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if !json.Valid(b) {
+		return "", fmt.Errorf("file %q does not contain valid JSON", c.DockerConfigJSONPath)
+	}
 	return string(b), nil
 }
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -126,7 +129,7 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := config.NewConfig(
-				config.WithDockerConfigJSON("xx"),
+				config.WithDockerConfigJSON(`{"auths":{}}`),
 				config.WithSecretNamespace("kube-system"),
 				config.WithServiceAccounts(tt.configServiceAccounts),
 			)
@@ -144,7 +147,7 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 
 func Test_IsManagedSecret(t *testing.T) {
 	cfg, err := config.NewConfig(
-		config.WithDockerConfigJSON("xx"),
+		config.WithDockerConfigJSON(`{"auths":{}}`),
 		config.WithSecretNamespace("kube-system"),
 	)
 	if err != nil {
@@ -260,6 +263,91 @@ func Test_HasAnnotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := HasAnnotation(tt.object, tt.annotationKey, tt.annotationValue); got != tt.want {
 				t.Errorf("HasAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetDockerConfigJSON(t *testing.T) {
+	const validJSON = `{"auths":{"registry.example.com":{"auth":"dGVzdDp0ZXN0"}}}`
+	const invalidJSON = `{"auths":{"registry.example.com":`
+
+	writeTempFile := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "dockerconfig.json")
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("failed to write temp file: %v", err)
+		}
+		return path
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) []config.ConfigOption
+		want    string
+		wantErr bool
+	}{
+		{
+			"valid inline JSON is returned as-is",
+			func(t *testing.T) []config.ConfigOption {
+				return []config.ConfigOption{config.WithDockerConfigJSON(validJSON)}
+			},
+			validJSON,
+			false,
+		},
+		{
+			"valid JSON from file is returned as-is",
+			func(t *testing.T) []config.ConfigOption {
+				return []config.ConfigOption{config.WithDockerConfigJSONPath(writeTempFile(t, validJSON))}
+			},
+			validJSON,
+			false,
+		},
+		{
+			"invalid JSON from file errors without leaking content",
+			func(t *testing.T) []config.ConfigOption {
+				return []config.ConfigOption{config.WithDockerConfigJSONPath(writeTempFile(t, invalidJSON))}
+			},
+			"",
+			true,
+		},
+		{
+			"empty file errors",
+			func(t *testing.T) []config.ConfigOption {
+				return []config.ConfigOption{config.WithDockerConfigJSONPath(writeTempFile(t, ""))}
+			},
+			"",
+			true,
+		},
+		{
+			"missing file errors",
+			func(t *testing.T) []config.ConfigOption {
+				return []config.ConfigOption{config.WithDockerConfigJSONPath(filepath.Join(t.TempDir(), "nonexistent.json"))}
+			},
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			cfg := &config.Config{SecretNamespace: "kube-system"}
+			for _, opt := range tt.setup(t) {
+				opt(cfg)
+			}
+
+			// Act
+			got, err := GetDockerConfigJSON(cfg)
+
+			// Assert
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetDockerConfigJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && strings.Contains(err.Error(), invalidJSON) {
+				t.Errorf("GetDockerConfigJSON() error message leaks file content: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("GetDockerConfigJSON() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- An empty or syntactically broken dockerconfigjson was accepted and synced into the managed secret of every namespace, breaking image pulls cluster-wide with cryptic kubelet errors.
- `config.NewConfig` now rejects an invalid inline `CONFIG_DOCKERCONFIGJSON` at startup; `utils.GetDockerConfigJSON` validates file content on every read (covers the file-watcher path).
- Error messages reference the file path only — never credential content (consistent with #201).
- Existing test fixtures using `xx` as a placeholder credential were updated to valid JSON.

## Test plan
- [x] New table cases in `Test_NewConfig_Validation` (invalid JSON, whitespace-only)
- [x] New `Test_GetDockerConfigJSON` (inline/file, valid/invalid/empty/missing, no content leak in errors)
- [ ] CI workflows green