### PR TITLE
fix(controller): fail open in predicates when namespace lookup fails

### DIFF
--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +48,23 @@ type SecretReconciler struct {
 func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
+	// Re-check the namespace here because the predicates fail open on
+	// namespace lookup errors. Without this, a cache hiccup could lead to
+	// patching secrets in excluded or terminating namespaces.
+	ns, err := utils.FetchNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// Namespace is gone (e.g. event queued during namespace deletion).
+			// The SA controller ensures secrets in new namespaces, so there is
+			// nothing left to do here.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to fetch namespace: %w", err)
+	}
+	if utils.IsNamespaceExcluded(r.Config, ns) || !ns.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	log.Info("Reconciling imagePullSecret in " + req.Namespace)
 	doPatch := false
 	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, req.Name, req.Namespace); err != nil {
@@ -72,40 +90,7 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("SecretController").
 		For(&corev1.Secret{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
-		WithEventFilter(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.Object.GetNamespace())
-				if err != nil {
-					return false
-				}
-				return utils.IsManagedSecret(r.Config, ns, e.Object)
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.ObjectNew.GetNamespace())
-				if err != nil {
-					return false
-				}
-				return utils.IsManagedSecret(r.Config, ns, e.ObjectNew)
-			},
-			GenericFunc: func(e event.GenericEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.Object.GetNamespace())
-				if err != nil {
-					return false
-				}
-				return utils.IsManagedSecret(r.Config, ns, e.Object)
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.Object.GetNamespace())
-				if err != nil {
-					return false
-				}
-				if !ns.DeletionTimestamp.IsZero() {
-					return false
-				}
-
-				return utils.IsManagedSecret(r.Config, ns, e.Object)
-			},
-		})
+		WithEventFilter(r.managedPredicate())
 
 	// If DockerConfigJSONPath is defined
 	if r.Config.DockerConfigJSONPath != "" && r.Config.FeatureWatchDockerConfigJSONPath {
@@ -150,4 +135,37 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return builder.Complete(r)
+}
+
+// managedPredicate filters events down to secrets this controller manages.
+// When the namespace lookup fails (e.g. a namespace not yet in the informer
+// cache), it fails open so Reconcile can re-check with proper error handling
+// instead of dropping the event permanently.
+func (r *SecretReconciler) managedPredicate() predicate.Funcs {
+	shouldProcess := func(obj client.Object) bool {
+		ns, err := utils.FetchNamespace(context.Background(), r.Client, obj.GetNamespace())
+		if err != nil {
+			log.Log.V(1).Info("failed to fetch namespace in predicate, processing event anyway",
+				"namespace", obj.GetNamespace(), "reason", err.Error())
+			return true
+		}
+		return utils.IsManagedSecret(r.Config, ns, obj)
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return shouldProcess(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return shouldProcess(e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return shouldProcess(e.Object) },
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			ns, err := utils.FetchNamespace(context.Background(), r.Client, e.Object.GetNamespace())
+			if err != nil {
+				// Fail open; Reconcile no-ops if the namespace is gone.
+				return true
+			}
+			if !ns.DeletionTimestamp.IsZero() {
+				// Do not recreate secrets in terminating namespaces.
+				return false
+			}
+			return utils.IsManagedSecret(r.Config, ns, e.Object)
+		},
+	}
 }

--- a/internal/controller/secret_controller_test.go
+++ b/internal/controller/secret_controller_test.go
@@ -17,16 +17,164 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/tamcore/imagepullsecret-patcher/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	saDefault        = "default"
+	annotationTrue   = "true"
+	secretNsManaged  = "secretns-managed"
+	secretNsExcluded = "secretns-excluded"
 )
 
 var _ = Describe("Secret Controller", func() {
-	Context("When reconciling a resource", func() {
+	ctx := context.Background()
+	cfg, err := config.NewConfig(
+		config.WithDockerConfigJSON(imagePullSecretData),
+		config.WithSecretNamespace("kube-system"),
+	)
+	if err != nil {
+		panic(err)
+	}
 
-		It("should successfully reconcile the resource", func() {
+	newTestScheme := func() *kruntime.Scheme {
+		scheme := kruntime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+		return scheme
+	}
 
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+	Context("When reconciling a Secret", func() {
+		It("should recreate the managed secret in a managed namespace", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: secretNsManaged}},
+			).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsManaged},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+			foundSecret := &corev1.Secret{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsManaged}, foundSecret)).To(Succeed())
+			Expect(string(foundSecret.Data[corev1.DockerConfigJsonKey])).To(Equal(imagePullSecretData))
+		})
+
+		It("should skip reconciliation for excluded namespaces", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:        secretNsExcluded,
+					Annotations: map[string]string{cfg.ExcludeAnnotation: annotationTrue},
+				}},
+			).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsExcluded},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+			foundSecret := &corev1.Secret{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsExcluded}, foundSecret)).NotTo(Succeed())
+		})
+
+		It("should return cleanly when the namespace no longer exists", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cfg.SecretName, Namespace: "secretns-gone"},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+	})
+
+	Context("When filtering events with managedPredicate", func() {
+		managedSecret := func(namespace string) *corev1.Secret {
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        cfg.SecretName,
+					Namespace:   namespace,
+					Annotations: map[string]string{config.AnnotationManagedBy: config.AnnotationAppName},
+				},
+			}
+		}
+
+		It("should process managed secrets in managed namespaces", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "predns-managed"}},
+			).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			pred := reconciler.managedPredicate()
+
+			Expect(pred.Create(event.CreateEvent{Object: managedSecret("predns-managed")})).To(BeTrue())
+			Expect(pred.Update(event.UpdateEvent{ObjectNew: managedSecret("predns-managed")})).To(BeTrue())
+			Expect(pred.Delete(event.DeleteEvent{Object: managedSecret("predns-managed")})).To(BeTrue())
+		})
+
+		It("should drop events in excluded namespaces", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:        "predns-excluded",
+					Annotations: map[string]string{cfg.ExcludeAnnotation: annotationTrue},
+				}},
+			).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			pred := reconciler.managedPredicate()
+
+			Expect(pred.Create(event.CreateEvent{Object: managedSecret("predns-excluded")})).To(BeFalse())
+		})
+
+		It("should fail open when the namespace lookup fails", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			pred := reconciler.managedPredicate()
+
+			Expect(pred.Create(event.CreateEvent{Object: managedSecret("predns-missing")})).To(BeTrue())
+			Expect(pred.Delete(event.DeleteEvent{Object: managedSecret("predns-missing")})).To(BeTrue())
+		})
+
+		It("should drop delete events for terminating namespaces", func() {
+			scheme := newTestScheme()
+			now := metav1.Now()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:              "predns-terminating",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"kubernetes"},
+				}},
+			).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			pred := reconciler.managedPredicate()
+
+			Expect(pred.Delete(event.DeleteEvent{Object: managedSecret("predns-terminating")})).To(BeFalse())
 		})
 	})
 })

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +35,11 @@ import (
 	"github.com/tamcore/imagepullsecret-patcher/internal/config"
 	"github.com/tamcore/imagepullsecret-patcher/internal/utils"
 )
+
+// namespaceCacheRetryDelay is how long to wait before retrying when an
+// object's namespace is not yet visible in the informer cache (e.g. a
+// brand-new namespace whose informer event hasn't arrived yet).
+const namespaceCacheRetryDelay = 10 * time.Second
 
 // ServiceAccountReconciler reconciles a ServiceAccount object
 type ServiceAccountReconciler struct {
@@ -64,6 +70,12 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Not a managed SA
 	ns, err := utils.FetchNamespace(ctx, r.Client, serviceAccount.GetNamespace())
 	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// The ServiceAccount exists but its namespace is not yet in the
+			// informer cache. Retry shortly; this resolves once the cache
+			// catches up, or stops once the SA disappears with its namespace.
+			return ctrl.Result{RequeueAfter: namespaceCacheRetryDelay}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to fetch namespace: %w", err)
 	}
 	if !utils.IsServiceAccountManaged(r.Config, ns, serviceAccount) {
@@ -100,39 +112,35 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	ctx := context.TODO()
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("ServiceAccountController").
 		For(&corev1.ServiceAccount{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
-		WithEventFilter(predicate.Funcs{
-			CreateFunc: func(e event.CreateEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.Object.GetNamespace())
-				if err != nil {
-					return false
-				}
-				return utils.IsServiceAccountManaged(r.Config, ns, e.Object)
-			},
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.ObjectNew.GetNamespace())
-				if err != nil {
-					return false
-				}
-				return utils.IsServiceAccountManaged(r.Config, ns, e.ObjectNew)
-			},
-			GenericFunc: func(e event.GenericEvent) bool {
-				ns, err := utils.FetchNamespace(ctx, r.Client, e.Object.GetNamespace())
-				if err != nil {
-					return false
-				}
-				return utils.IsServiceAccountManaged(r.Config, ns, e.Object)
-			},
-			// Ignore Deletion events
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				return false
-			},
-		}).
+		WithEventFilter(r.managedPredicate()).
 		Complete(r)
+}
+
+// managedPredicate filters events down to ServiceAccounts this controller
+// manages. When the namespace lookup fails (e.g. a brand-new namespace not
+// yet in the informer cache), it fails open so Reconcile can re-check with
+// proper error handling instead of dropping the event permanently.
+func (r *ServiceAccountReconciler) managedPredicate() predicate.Funcs {
+	shouldProcess := func(obj client.Object) bool {
+		ns, err := utils.FetchNamespace(context.Background(), r.Client, obj.GetNamespace())
+		if err != nil {
+			log.Log.V(1).Info("failed to fetch namespace in predicate, processing event anyway",
+				"namespace", obj.GetNamespace(), "reason", err.Error())
+			return true
+		}
+		return utils.IsServiceAccountManaged(r.Config, ns, obj)
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return shouldProcess(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return shouldProcess(e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return shouldProcess(e.Object) },
+		// Ignore Deletion events
+		DeleteFunc: func(e event.DeleteEvent) bool { return false },
+	}
 }
 
 // Check if service account contains imagePullSecret with name equal to secretName

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -78,7 +79,7 @@ var _ = Describe("ServiceAccount Controller", func() {
 		}
 
 		It("should successfully reconcile the resource", func() {
-			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-1", "default", cfg.SecretName)
+			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-1", saDefault, cfg.SecretName)
 
 			By("Creating the Namespace to perform the tests")
 			Expect(k8sClient.Create(ctx, namespace.DeepCopy())).Should(Succeed())
@@ -214,14 +215,14 @@ var _ = Describe("ServiceAccount Controller", func() {
 		})
 
 		It("should not reconcile the resource", func() {
-			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-2", "default", cfg.SecretName)
+			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-2", saDefault, cfg.SecretName)
 
 			By("Creating the Namespace to perform the tests")
 			Expect(k8sClient.Create(ctx, namespace.DeepCopy())).Should(Succeed())
 
 			By("Creating the ServiceAccount to reconcile")
 			serviceAccount.Annotations = map[string]string{
-				cfg.ExcludeAnnotation: "true",
+				cfg.ExcludeAnnotation: annotationTrue,
 			}
 			Expect(k8sClient.Create(ctx, serviceAccount.DeepCopy())).Should(Succeed())
 
@@ -260,7 +261,7 @@ var _ = Describe("ServiceAccount Controller", func() {
 		}
 
 		It("should adopt the pre-existing secret and add managed-by labels", func() {
-			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-upgrade", "default", cfg.SecretName)
+			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-upgrade", saDefault, cfg.SecretName)
 
 			oldSecretData := `{"auth":{"old.example.com":{}}}`
 			preExistingSecret := &corev1.Secret{
@@ -339,6 +340,69 @@ var _ = Describe("ServiceAccount Controller", func() {
 				NamespacedName: serviceAccountNN,
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When the namespace is not yet visible in the cache", func() {
+		ctx := context.Background()
+		cfg, err := config.NewConfig(
+			config.WithDockerConfigJSON(imagePullSecretData),
+			config.WithSecretNamespace("kube-system"),
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		newFakeClient := func(objs ...client.Object) client.Client {
+			scheme := kruntime.NewScheme()
+			Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+			return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		}
+
+		It("should requeue instead of dropping the ServiceAccount", func() {
+			serviceAccount := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: saDefault, Namespace: "ns-not-in-cache"},
+			}
+			c := newFakeClient(serviceAccount)
+			reconciler := &ServiceAccountReconciler{Client: c, Scheme: c.Scheme(), Config: cfg}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: saDefault, Namespace: "ns-not-in-cache"},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(namespaceCacheRetryDelay))
+		})
+
+		It("should fail open in predicates so Reconcile can decide", func() {
+			c := newFakeClient(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "sa-predns-managed"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:        "sa-predns-excluded",
+					Annotations: map[string]string{cfg.ExcludeAnnotation: annotationTrue},
+				}},
+			)
+			reconciler := &ServiceAccountReconciler{Client: c, Scheme: c.Scheme(), Config: cfg}
+			pred := reconciler.managedPredicate()
+
+			saIn := func(namespace string) *corev1.ServiceAccount {
+				return &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: saDefault, Namespace: namespace},
+				}
+			}
+
+			By("processing ServiceAccounts in managed namespaces")
+			Expect(pred.Create(event.CreateEvent{Object: saIn("sa-predns-managed")})).To(BeTrue())
+			Expect(pred.Update(event.UpdateEvent{ObjectNew: saIn("sa-predns-managed")})).To(BeTrue())
+
+			By("dropping ServiceAccounts in excluded namespaces")
+			Expect(pred.Create(event.CreateEvent{Object: saIn("sa-predns-excluded")})).To(BeFalse())
+
+			By("failing open when the namespace lookup fails")
+			Expect(pred.Create(event.CreateEvent{Object: saIn("sa-predns-missing")})).To(BeTrue())
+
+			By("still ignoring delete events")
+			Expect(pred.Delete(event.DeleteEvent{Object: saIn("sa-predns-managed")})).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Both controllers' predicates silently returned `false` when `FetchNamespace` failed. Race: a brand-new namespace's `default` ServiceAccount event can arrive before the namespace informer catches up → NotFound → event dropped permanently (no resync for ~10h), leaving the namespace unpatched.
- Predicates now **fail open** (log at V(1) + process the event); Reconcile re-checks with proper error handling:
  - `ServiceAccountReconciler`: namespace NotFound → `RequeueAfter: 10s` (self-terminating — once the SA disappears with its namespace, reconciliation stops cleanly).
  - `SecretReconciler`: gains the namespace re-check it previously lacked (excluded/terminating skip) — mandatory so fail-open can't patch secrets in excluded namespaces.
- Inline predicates extracted into testable `managedPredicate()` constructors; setup-time `context.TODO()` removed.

## Test plan
- [x] Predicate tests: managed → true, excluded → false, missing namespace → true (fail open), SA delete → false, terminating-namespace secret delete → false
- [x] Reconcile tests: SA requeues when namespace invisible; secret reconcile skips excluded and gone namespaces; replaces the `secret_controller_test.go` stub
- [ ] CI workflows green