### PR TITLE
fix(utils): hoist namespace lookup and avoid duplicate pod deletes

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -127,33 +127,43 @@ func FetchServiceAccount(ctx context.Context, client client.Client, namespace st
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
 
 func CleanupPodsForNamespace(ctx context.Context, c *config.Config, k8sClient client.Client, namespace string) error {
+	ns, err := FetchNamespace(ctx, k8sClient, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to fetch namespace: %w", err)
+	}
+	if IsNamespaceExcluded(c, ns) {
+		return nil
+	}
+
 	podList := &corev1.PodList{}
 	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace)); err != nil {
 		return fmt.Errorf("failed to fetch pods: %w", err)
 	}
 
+	// Cache the managed-state per ServiceAccount so pods sharing one don't
+	// trigger repeated lookups.
+	saManaged := map[string]bool{}
 	for _, pod := range podList.Items {
-		ns, err := FetchNamespace(ctx, k8sClient, namespace)
-		if err != nil {
-			return fmt.Errorf("failed to fetch namespace: %w", err)
+		managed, known := saManaged[pod.Spec.ServiceAccountName]
+		if !known {
+			sa, err := FetchServiceAccount(ctx, k8sClient, namespace, pod.Spec.ServiceAccountName)
+			if err != nil {
+				if apierrs.IsNotFound(err) {
+					// The ServiceAccount is gone; its pods are not managed by us.
+					saManaged[pod.Spec.ServiceAccountName] = false
+					continue
+				}
+				return fmt.Errorf("failed to fetch serviceAccount: %w", err)
+			}
+			managed = IsServiceAccountManaged(c, ns, sa)
+			saManaged[pod.Spec.ServiceAccountName] = managed
 		}
-		sa, err := FetchServiceAccount(ctx, k8sClient, namespace, pod.Spec.ServiceAccountName)
-		if err != nil {
-			return fmt.Errorf("failed to fetch serviceAccount: %w", err)
-		}
-		if !IsServiceAccountManaged(c, ns, sa) {
+		if !managed {
 			continue
 		}
 
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.State.Waiting != nil {
-				if containerStatus.State.Waiting.Reason == "ErrImagePull" || containerStatus.State.Waiting.Reason == "ImagePullBackOff" {
-					log.FromContext(ctx).Info("Deleting Pod " + pod.Name + " in " + pod.Namespace + " due to status " + containerStatus.State.Waiting.Reason)
-					if err := k8sClient.Delete(ctx, &pod); err != nil {
-						return fmt.Errorf("failed to delete Pod "+pod.Name+"in "+pod.Namespace+": %w", err)
-					}
-				}
-			}
+		if err := deletePodIfImagePullFailed(ctx, k8sClient, &pod); err != nil {
+			return err
 		}
 	}
 
@@ -171,18 +181,35 @@ func CleanupPodsForSA(ctx context.Context, k8sClient client.Client, namespace st
 			continue
 		}
 
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.State.Waiting != nil {
-				if containerStatus.State.Waiting.Reason == "ErrImagePull" || containerStatus.State.Waiting.Reason == "ImagePullBackOff" {
-					log.FromContext(ctx).Info("Deleting Pod " + pod.Name + " in " + pod.Namespace + " due to status " + containerStatus.State.Waiting.Reason)
-					if err := k8sClient.Delete(ctx, &pod); err != nil {
-						return fmt.Errorf("failed to delete Pod "+pod.Name+"in "+pod.Namespace+": %w", err)
-					}
-				}
-			}
+		if err := deletePodIfImagePullFailed(ctx, k8sClient, &pod); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// deletePodIfImagePullFailed deletes the pod once if any of its containers is
+// stuck in an image pull failure. An already-deleted pod is not an error.
+func deletePodIfImagePullFailed(ctx context.Context, k8sClient client.Client, pod *corev1.Pod) error {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.State.Waiting == nil {
+			continue
+		}
+		reason := containerStatus.State.Waiting.Reason
+		if reason != "ErrImagePull" && reason != "ImagePullBackOff" {
+			continue
+		}
+
+		log.FromContext(ctx).Info("Deleting Pod due to image pull failure",
+			"pod", pod.Name, "namespace", pod.Namespace, "reason", reason)
+		if err := k8sClient.Delete(ctx, pod); err != nil && !apierrs.IsNotFound(err) {
+			return fmt.Errorf("failed to delete Pod %q in namespace %q: %w", pod.Name, pod.Namespace, err)
+		}
+		// The pod is deleted; checking the remaining containers would only
+		// trigger redundant deletes.
+		return nil
+	}
 	return nil
 }
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -17,19 +17,29 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/tamcore/imagepullsecret-patcher/internal/config"
 )
 
-const nsDefault = "default"
+const (
+	nsDefault      = "default"
+	annotationTrue = "true"
+)
 
 var (
 	True  = true
@@ -90,7 +100,7 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: nsDefault,
 						Annotations: map[string]string{
-							"pborn.eu/imagepullsecret-patcher-exclude": "true",
+							"pborn.eu/imagepullsecret-patcher-exclude": annotationTrue,
 						},
 					},
 				},
@@ -117,7 +127,7 @@ func Test_IsServiceAccountManaged(t *testing.T) {
 						Name:      nsDefault,
 						Namespace: nsDefault,
 						Annotations: map[string]string{
-							"pborn.eu/imagepullsecret-patcher-exclude": "true",
+							"pborn.eu/imagepullsecret-patcher-exclude": annotationTrue,
 						},
 					},
 				},
@@ -263,6 +273,208 @@ func Test_HasAnnotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := HasAnnotation(tt.object, tt.annotationKey, tt.annotationValue); got != tt.want {
 				t.Errorf("HasAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newCleanupTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg, err := config.NewConfig(
+		config.WithDockerConfigJSON(`{"auths":{}}`),
+		config.WithSecretNamespace("kube-system"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+	return cfg
+}
+
+func newFailingPod(name string, namespace string, serviceAccount string, reasons ...string) *corev1.Pod {
+	statuses := make([]corev1.ContainerStatus, 0, len(reasons))
+	for _, reason := range reasons {
+		statuses = append(statuses, corev1.ContainerStatus{
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: reason},
+			},
+		})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       corev1.PodSpec{ServiceAccountName: serviceAccount},
+		Status:     corev1.PodStatus{ContainerStatuses: statuses},
+	}
+}
+
+func newCountingClient(deletes *int, saGets *int, deleteNotFound bool, objs ...client.Object) client.Client {
+	scheme := kruntime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				*deletes++
+				if deleteNotFound {
+					return apierrs.NewNotFound(schema.GroupResource{Resource: "pods"}, obj.GetName())
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ServiceAccount); ok {
+					*saGets++
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+}
+
+func Test_CleanupPodsForNamespace(t *testing.T) {
+	managedNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsDefault}}
+	managedSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: nsDefault, Namespace: nsDefault}}
+	unmanagedSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: nsDefault}}
+
+	tests := []struct {
+		name           string
+		objects        []client.Object
+		deleteNotFound bool
+		wantDeletes    int
+		maxSAGets      int
+		wantErr        bool
+	}{
+		{
+			"pod with two failing containers is deleted exactly once",
+			[]client.Object{
+				managedNamespace.DeepCopy(), managedSA.DeepCopy(),
+				newFailingPod("pod-a", nsDefault, nsDefault, "ErrImagePull", "ImagePullBackOff"),
+			},
+			false, 1, 1, false,
+		},
+		{
+			"pods sharing a serviceaccount fetch it only once",
+			[]client.Object{
+				managedNamespace.DeepCopy(), managedSA.DeepCopy(),
+				newFailingPod("pod-a", nsDefault, nsDefault, "ErrImagePull"),
+				newFailingPod("pod-b", nsDefault, nsDefault, "ImagePullBackOff"),
+			},
+			false, 2, 1, false,
+		},
+		{
+			"pod of unmanaged serviceaccount is kept",
+			[]client.Object{
+				managedNamespace.DeepCopy(), managedSA.DeepCopy(), unmanagedSA.DeepCopy(),
+				newFailingPod("pod-a", nsDefault, "other", "ErrImagePull"),
+			},
+			false, 0, 1, false,
+		},
+		{
+			"already-deleted pod is tolerated",
+			[]client.Object{
+				managedNamespace.DeepCopy(), managedSA.DeepCopy(),
+				newFailingPod("pod-a", nsDefault, nsDefault, "ErrImagePull"),
+			},
+			true, 1, 1, false,
+		},
+		{
+			"healthy pods are kept",
+			[]client.Object{
+				managedNamespace.DeepCopy(), managedSA.DeepCopy(),
+				newFailingPod("pod-a", nsDefault, nsDefault),
+			},
+			false, 0, 1, false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			cfg := newCleanupTestConfig(t)
+			deletes, saGets := 0, 0
+			c := newCountingClient(&deletes, &saGets, tt.deleteNotFound, tt.objects...)
+
+			// Act
+			err := CleanupPodsForNamespace(context.Background(), cfg, c, nsDefault)
+
+			// Assert
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CleanupPodsForNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if deletes != tt.wantDeletes {
+				t.Errorf("CleanupPodsForNamespace() deletes = %d, want %d", deletes, tt.wantDeletes)
+			}
+			if saGets > tt.maxSAGets {
+				t.Errorf("CleanupPodsForNamespace() serviceaccount gets = %d, want at most %d", saGets, tt.maxSAGets)
+			}
+		})
+	}
+
+	t.Run("excluded namespace deletes nothing", func(t *testing.T) {
+		// Arrange
+		cfg := newCleanupTestConfig(t)
+		excludedNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:        "kube-excluded",
+			Annotations: map[string]string{cfg.ExcludeAnnotation: annotationTrue},
+		}}
+		deletes, saGets := 0, 0
+		c := newCountingClient(&deletes, &saGets, false,
+			excludedNamespace,
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: nsDefault, Namespace: "kube-excluded"}},
+			newFailingPod("pod-a", "kube-excluded", nsDefault, "ErrImagePull"),
+		)
+
+		// Act
+		err := CleanupPodsForNamespace(context.Background(), cfg, c, "kube-excluded")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("CleanupPodsForNamespace() unexpected error: %v", err)
+		}
+		if deletes != 0 {
+			t.Errorf("CleanupPodsForNamespace() deletes = %d, want 0", deletes)
+		}
+	})
+}
+
+func Test_CleanupPodsForSA(t *testing.T) {
+	tests := []struct {
+		name           string
+		objects        []client.Object
+		deleteNotFound bool
+		wantDeletes    int
+	}{
+		{
+			"pod with two failing containers is deleted exactly once",
+			[]client.Object{newFailingPod("pod-a", nsDefault, nsDefault, "ErrImagePull", "ImagePullBackOff")},
+			false, 1,
+		},
+		{
+			"pod of other serviceaccount is kept",
+			[]client.Object{newFailingPod("pod-a", nsDefault, "other", "ErrImagePull")},
+			false, 0,
+		},
+		{
+			"already-deleted pod is tolerated",
+			[]client.Object{newFailingPod("pod-a", nsDefault, nsDefault, "ErrImagePull")},
+			true, 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			deletes, saGets := 0, 0
+			c := newCountingClient(&deletes, &saGets, tt.deleteNotFound, tt.objects...)
+
+			// Act
+			err := CleanupPodsForSA(context.Background(), c, nsDefault, nsDefault)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("CleanupPodsForSA() unexpected error: %v", err)
+			}
+			if deletes != tt.wantDeletes {
+				t.Errorf("CleanupPodsForSA() deletes = %d, want %d", deletes, tt.wantDeletes)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `CleanupPodsForNamespace` fetched the namespace **once per pod** and the ServiceAccount once per pod even when shared; pods with several containers in `ErrImagePull`/`ImagePullBackOff` were deleted once per failing container.
- Namespace fetch hoisted above the loop with an excluded-namespace early return; per-ServiceAccount managed-state cache; one delete per pod via a shared `deletePodIfImagePullFailed` helper (also used by `CleanupPodsForSA`).
- Hardening: NotFound on delete (pod already gone) and a deleted ServiceAccount (skip its pods) no longer abort the cleanup.

## Test plan
- [x] New table-driven `Test_CleanupPodsForNamespace`/`Test_CleanupPodsForSA` with interceptors counting Delete/Get calls (single delete for two failing containers, SA fetched once, excluded namespace untouched, NotFound tolerated)
- [ ] CI workflows green