### PR TITLE
fix(controller): drop secretName conflation in secret reconciliation

### DIFF
--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -48,6 +48,13 @@ type SecretReconciler struct {
 func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
+	// Only the managed imagePullSecret itself is reconciled here. Requests for
+	// other secrets (e.g. annotated ones, or channel-sourced events) must not be
+	// conflated with the secret named in the configuration.
+	if req.Name != r.Config.SecretName {
+		return ctrl.Result{}, nil
+	}
+
 	// Re-check the namespace here because the predicates fail open on
 	// namespace lookup errors. Without this, a cache hiccup could lead to
 	// patching secrets in excluded or terminating namespaces.
@@ -67,7 +74,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	log.Info("Reconciling imagePullSecret in " + req.Namespace)
 	doPatch := false
-	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, req.Name, req.Namespace); err != nil {
+	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, req.Namespace); err != nil {
 		return ctrl.Result{}, fmt.Errorf("Failed to reconcile imagePullSecret in Namespace '"+req.Namespace+"': %w", err)
 	} else {
 		doPatch = didPatch

--- a/internal/controller/secret_controller_test.go
+++ b/internal/controller/secret_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/tamcore/imagepullsecret-patcher/internal/config"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -106,6 +107,46 @@ var _ = Describe("Secret Controller", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
+		})
+
+		It("should ignore an annotated secret whose name differs from the managed secret", func() {
+			scheme := newTestScheme()
+			namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "secretns-foreign"}}
+			foreignSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "something-else",
+					Namespace:   namespace.GetName(),
+					Annotations: map[string]string{config.AnnotationManagedBy: config.AnnotationAppName},
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{"foo": []byte("bar")},
+			}
+			foreignSecretNN := types.NamespacedName{
+				Name:      foreignSecret.GetName(),
+				Namespace: foreignSecret.GetNamespace(),
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(namespace, foreignSecret).Build()
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg}
+
+			By("Snapshotting the foreign secret before reconciliation")
+			before := &corev1.Secret{}
+			Expect(c.Get(ctx, foreignSecretNN, before)).To(Succeed())
+
+			By("Reconciling a request for the foreign secret")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: foreignSecretNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the managed secret was NOT created")
+			managed := &corev1.Secret{}
+			err = c.Get(ctx, types.NamespacedName{Name: cfg.SecretName, Namespace: namespace.GetName()}, managed)
+			Expect(apierrs.IsNotFound(err)).To(BeTrue())
+
+			By("Verifying the foreign secret is untouched")
+			after := &corev1.Secret{}
+			Expect(c.Get(ctx, foreignSecretNN, after)).To(Succeed())
+			Expect(after.ResourceVersion).To(Equal(before.ResourceVersion))
+			Expect(after.Data).To(Equal(map[string][]byte{"foo": []byte("bar")}))
+			Expect(after.Type).To(Equal(corev1.SecretTypeOpaque))
 		})
 	})
 

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -83,7 +83,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Ensure imagePullSecret exists before we attach it to the ServiceAccount
-	if _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, r.Config.SecretName, serviceAccount.GetNamespace()); err != nil {
+	if _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, serviceAccount.GetNamespace()); err != nil {
 		return ctrl.Result{}, fmt.Errorf("Failed to reconcile imagePullSecret in Namespace '"+serviceAccount.GetNamespace()+"': %w", err)
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -213,7 +213,7 @@ func deletePodIfImagePullFailed(ctx context.Context, k8sClient client.Client, po
 	return nil
 }
 
-func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, c *config.Config, secretName string, namespace string) (bool, error) {
+func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, c *config.Config, namespace string) (bool, error) {
 	desiredSecret, err := ConstructImagePullSecret(c, namespace)
 	if err != nil {
 		return false, fmt.Errorf("failed to construct imagePullSecret: %v", err)
@@ -222,7 +222,7 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, c *c
 	secret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx,
 		types.NamespacedName{
-			Name:      secretName,
+			Name:      c.SecretName,
 			Namespace: namespace,
 		},
 		secret,

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -560,6 +561,137 @@ func Test_GetDockerConfigJSON(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("GetDockerConfigJSON() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- ReconcileImagePullSecret tests ---
+// NOTE: keep these at the end of the file to minimize merge conflicts.
+
+const (
+	secretNamespaceTest    = "kube-system"
+	reconcileDockerCfgJSON = `{"auths":{"reconcile.example.com":{"auth":"dGVzdDp0ZXN0"}}}`
+)
+
+func newReconcileTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg, err := config.NewConfig(
+		config.WithDockerConfigJSON(reconcileDockerCfgJSON),
+		config.WithSecretNamespace(secretNamespaceTest),
+	)
+	if err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+	return cfg
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := kruntime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to build scheme: %v", err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+}
+
+func desiredSecretFixture(t *testing.T, cfg *config.Config, mutate func(*corev1.Secret)) *corev1.Secret {
+	t.Helper()
+	secret, err := ConstructImagePullSecret(cfg, nsDefault)
+	if err != nil {
+		t.Fatalf("failed to construct imagePullSecret: %v", err)
+	}
+	if mutate != nil {
+		mutate(secret)
+	}
+	return secret
+}
+
+func Test_ReconcileImagePullSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		existing    func(t *testing.T, cfg *config.Config) *corev1.Secret
+		wantChanged bool
+		assert      func(t *testing.T, cfg *config.Config, got *corev1.Secret)
+	}{
+		{
+			name:        "creates the managed secret when absent",
+			existing:    nil,
+			wantChanged: true,
+			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
+				if got.Name != cfg.SecretName {
+					t.Errorf("secret name = %q, want %q", got.Name, cfg.SecretName)
+				}
+				if got.Type != corev1.SecretTypeDockerConfigJson {
+					t.Errorf("secret type = %q, want %q", got.Type, corev1.SecretTypeDockerConfigJson)
+				}
+				if data := string(got.Data[corev1.DockerConfigJsonKey]); data != reconcileDockerCfgJSON {
+					t.Errorf("secret data = %q, want %q", data, reconcileDockerCfgJSON)
+				}
+				if got.Labels[config.LabelManagedBy] != config.AnnotationAppName {
+					t.Errorf("managed-by label = %q, want %q", got.Labels[config.LabelManagedBy], config.AnnotationAppName)
+				}
+				if got.Annotations[config.AnnotationManagedBy] != config.AnnotationAppName {
+					t.Errorf("managed-by annotation = %q, want %q",
+						got.Annotations[config.AnnotationManagedBy], config.AnnotationAppName)
+				}
+			},
+		},
+		{
+			name: "patches the managed secret when data is stale",
+			existing: func(t *testing.T, cfg *config.Config) *corev1.Secret {
+				return desiredSecretFixture(t, cfg, func(s *corev1.Secret) {
+					s.Data = map[string][]byte{
+						corev1.DockerConfigJsonKey: []byte(`{"auths":{"stale.example.com":{}}}`),
+					}
+				})
+			},
+			wantChanged: true,
+			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
+				if data := string(got.Data[corev1.DockerConfigJsonKey]); data != reconcileDockerCfgJSON {
+					t.Errorf("secret data = %q, want %q", data, reconcileDockerCfgJSON)
+				}
+			},
+		},
+		{
+			name: "returns false when the managed secret is up-to-date",
+			existing: func(t *testing.T, cfg *config.Config) *corev1.Secret {
+				return desiredSecretFixture(t, cfg, nil)
+			},
+			wantChanged: false,
+			assert:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			cfg := newReconcileTestConfig(t)
+			var objs []client.Object
+			if tt.existing != nil {
+				objs = append(objs, tt.existing(t, cfg))
+			}
+			k8sClient := newFakeClient(t, objs...)
+
+			// Act
+			changed, err := ReconcileImagePullSecret(context.Background(), k8sClient, cfg, nsDefault)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("ReconcileImagePullSecret() error = %v", err)
+			}
+			if changed != tt.wantChanged {
+				t.Errorf("ReconcileImagePullSecret() changed = %v, want %v", changed, tt.wantChanged)
+			}
+			got := &corev1.Secret{}
+			if err := k8sClient.Get(context.Background(),
+				types.NamespacedName{Name: cfg.SecretName, Namespace: nsDefault}, got); err != nil {
+				t.Fatalf("failed to fetch reconciled Secret: %v", err)
+			}
+			if tt.assert != nil {
+				tt.assert(t, cfg, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `utils.ReconcileImagePullSecret` fetched the secret named by its `secretName` parameter (the SecretReconciler passed `req.Name`) but created/patched a secret named `config.SecretName` — a secret carrying the managed-by annotation under a *different* name was "reconciled" against the wrong object (and previously had credentials synced into it).
- The parameter is removed; the function always operates on `config.SecretName`. `SecretReconciler.Reconcile` ignores requests whose name differs from the configured secret name (guard in Reconcile so channel-sourced events are covered too).
- Behavior change to note: foreign-named annotated secrets are now ignored instead of receiving credential syncs.

## Test plan
- [x] New table-driven `Test_ReconcileImagePullSecret` (created with correct name/type/data/labels; stale → patched; up-to-date → no patch)
- [x] Ginkgo: annotated secret named `something-else` is left untouched (ResourceVersion asserted) and no managed secret is created
- [ ] CI workflows green

Implemented by a sub-agent in an isolated worktree; integrated and conflict-resolved against current master.