### PR TITLE
fix(utils): merge managed fields instead of replacing annotations

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -242,22 +242,49 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, c *c
 		return false, fmt.Errorf("while fetching Secret: %v", err)
 	}
 
-	inClusterSecret := secret.DeepCopy()
 	patchFrom := client.MergeFrom(secret.DeepCopy())
-	secret.Annotations = desiredSecret.Annotations
-	secret.Data = desiredSecret.Data
 
-	doPatch := !reflect.DeepEqual(inClusterSecret.Annotations, desiredSecret.Annotations)
+	// Enforce managed annotations/labels key-wise, so that annotations or labels
+	// added by users or third-party controllers are preserved. The managed-by
+	// label is enforced here as well, to keep hand-edited secrets inside the
+	// label-filtered cache.
+	annotations, annotationsChanged := enforceMapEntries(secret.Annotations, desiredSecret.Annotations)
+	labels, labelsChanged := enforceMapEntries(secret.Labels, desiredSecret.Labels)
+	secret.Annotations = annotations
+	secret.Labels = labels
 
-	if !reflect.DeepEqual(inClusterSecret.Data, desiredSecret.Data) {
+	doPatch := annotationsChanged || labelsChanged
+	if !reflect.DeepEqual(secret.Data, desiredSecret.Data) {
+		secret.Data = desiredSecret.Data
 		doPatch = true
 	}
+
 	if doPatch {
 		if err = k8sClient.Patch(ctx, secret, patchFrom); err != nil {
 			return false, fmt.Errorf("error while patching Secret '"+desiredSecret.GetName()+"' in namespace '"+desiredSecret.GetNamespace()+"': %v", err)
 		}
 	}
 	return doPatch, nil
+}
+
+// enforceMapEntries returns a copy of current with every key/value pair from
+// desired enforced. Keys present only in current (e.g. user or third-party
+// annotations/labels) are preserved. The boolean reports whether any desired
+// entry was missing or differing.
+func enforceMapEntries(current map[string]string, desired map[string]string) (map[string]string, bool) {
+	merged := make(map[string]string, len(current)+len(desired))
+	for k, v := range current {
+		merged[k] = v
+	}
+
+	changed := false
+	for k, v := range desired {
+		if existing, ok := merged[k]; !ok || existing != v {
+			merged[k] = v
+			changed = true
+		}
+	}
+	return merged, changed
 }
 
 // patchUnmanagedSecret patches an existing secret that is not in the label-filtered cache.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -572,6 +572,8 @@ func Test_GetDockerConfigJSON(t *testing.T) {
 const (
 	secretNamespaceTest    = "kube-system"
 	reconcileDockerCfgJSON = `{"auths":{"reconcile.example.com":{"auth":"dGVzdDp0ZXN0"}}}`
+	foreignAnnotationKey   = "cert-manager.io/foo"
+	foreignAnnotationValue = "bar"
 )
 
 func newReconcileTestConfig(t *testing.T) *config.Config {
@@ -663,6 +665,57 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 			},
 			wantChanged: false,
 			assert:      nil,
+		},
+		{
+			name: "preserves foreign annotations and skips patch when up-to-date",
+			existing: func(t *testing.T, cfg *config.Config) *corev1.Secret {
+				return desiredSecretFixture(t, cfg, func(s *corev1.Secret) {
+					s.Annotations[foreignAnnotationKey] = foreignAnnotationValue
+				})
+			},
+			wantChanged: false,
+			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
+				if got.Annotations[foreignAnnotationKey] != foreignAnnotationValue {
+					t.Errorf("foreign annotation = %q, want %q",
+						got.Annotations[foreignAnnotationKey], foreignAnnotationValue)
+				}
+			},
+		},
+		{
+			name: "restores the managed annotation while preserving foreign annotations",
+			existing: func(t *testing.T, cfg *config.Config) *corev1.Secret {
+				return desiredSecretFixture(t, cfg, func(s *corev1.Secret) {
+					s.Annotations = map[string]string{
+						foreignAnnotationKey: foreignAnnotationValue,
+					}
+				})
+			},
+			wantChanged: true,
+			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
+				if got.Annotations[config.AnnotationManagedBy] != config.AnnotationAppName {
+					t.Errorf("managed-by annotation = %q, want %q",
+						got.Annotations[config.AnnotationManagedBy], config.AnnotationAppName)
+				}
+				if got.Annotations[foreignAnnotationKey] != foreignAnnotationValue {
+					t.Errorf("foreign annotation = %q, want %q",
+						got.Annotations[foreignAnnotationKey], foreignAnnotationValue)
+				}
+			},
+		},
+		{
+			name: "restores the managed label when missing",
+			existing: func(t *testing.T, cfg *config.Config) *corev1.Secret {
+				return desiredSecretFixture(t, cfg, func(s *corev1.Secret) {
+					s.Labels = nil
+				})
+			},
+			wantChanged: true,
+			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
+				if got.Labels[config.LabelManagedBy] != config.AnnotationAppName {
+					t.Errorf("managed-by label = %q, want %q",
+						got.Labels[config.LabelManagedBy], config.AnnotationAppName)
+				}
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- The update path in `ReconcileImagePullSecret` replaced the secret's annotations wholesale — the MergeFrom patch then stripped any user/third-party annotations from the managed secret, fighting other controllers.
- Desired annotations and labels are now enforced key-wise (foreign keys preserved); `Data` replaced only on actual drift; patch issued only when something changed.
- Bonus: the `app.kubernetes.io/managed-by` **label** is now also enforced in the update path (previously only set at Create) — keeps hand-edited secrets inside the label-filtered cache.

## Test plan
- [x] Table cases: foreign annotations preserved + no patch when up-to-date; managed annotation restored with foreign keys intact; managed label restored
- [ ] CI workflows green

Stacked on #210 (merged). Implemented by a sub-agent in an isolated worktree; integrated against current master.