### PR TITLE
fix(utils): handle wrong-type pre-existing secret during adoption

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -209,18 +209,20 @@ func main() {
 	}
 
 	if err = (&controller.ServiceAccountReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Config: controllerConfig,
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Config:    controllerConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceAccount")
 		os.Exit(1)
 	}
 
 	if err = (&controller.SecretReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Config: controllerConfig,
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Config:    controllerConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Secret")
 		os.Exit(1)

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -39,8 +39,11 @@ import (
 // SecretReconciler reconciles a Secret object
 type SecretReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Config *config.Config
+	// APIReader reads directly from the API server, bypassing the
+	// label-filtered cache (used to inspect pre-existing secrets).
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Config    *config.Config
 }
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
@@ -74,7 +77,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	log.Info("Reconciling imagePullSecret in " + req.Namespace)
 	doPatch := false
-	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, req.Namespace); err != nil {
+	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, req.Namespace); err != nil {
 		return ctrl.Result{}, fmt.Errorf("Failed to reconcile imagePullSecret in Namespace '"+req.Namespace+"': %w", err)
 	} else {
 		doPatch = didPatch

--- a/internal/controller/secret_controller_test.go
+++ b/internal/controller/secret_controller_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 const (
+	kubeSystemNs     = "kube-system"
 	saDefault        = "default"
 	annotationTrue   = "true"
 	secretNsManaged  = "secretns-managed"
@@ -45,7 +46,7 @@ var _ = Describe("Secret Controller", func() {
 	ctx := context.Background()
 	cfg, err := config.NewConfig(
 		config.WithDockerConfigJSON(imagePullSecretData),
-		config.WithSecretNamespace("kube-system"),
+		config.WithSecretNamespace(kubeSystemNs),
 	)
 	if err != nil {
 		panic(err)

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -44,8 +44,11 @@ const namespaceCacheRetryDelay = 10 * time.Second
 // ServiceAccountReconciler reconciles a ServiceAccount object
 type ServiceAccountReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Config *config.Config
+	// APIReader reads directly from the API server, bypassing the
+	// label-filtered cache (used to inspect pre-existing secrets).
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Config    *config.Config
 }
 
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;update;patch
@@ -83,7 +86,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Ensure imagePullSecret exists before we attach it to the ServiceAccount
-	if _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.Config, serviceAccount.GetNamespace()); err != nil {
+	if _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, serviceAccount.GetNamespace()); err != nil {
 		return ctrl.Result{}, fmt.Errorf("Failed to reconcile imagePullSecret in Namespace '"+serviceAccount.GetNamespace()+"': %w", err)
 	}
 

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -65,13 +65,34 @@ func makeObjects(namespaceName string, serviceAccountName string, secretName str
 	return namespace, serviceAccount, serviceAccountNN, secretNN
 }
 
+// unlabeledSecretsNotFound is a Get interceptor simulating the label-filtered
+// cache used in production: secrets without the managed-by label are invisible
+// to Get (NotFound) while still existing in the API server (Create returns
+// AlreadyExists).
+func unlabeledSecretsNotFound(
+	ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption,
+) error {
+	if err := c.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if secret, ok := obj.(*corev1.Secret); ok {
+		if secret.Labels[config.LabelManagedBy] != config.AnnotationAppName {
+			return apierrs.NewNotFound(
+				schema.GroupResource{Group: "", Resource: "secrets"},
+				key.Name,
+			)
+		}
+	}
+	return nil
+}
+
 var _ = Describe("ServiceAccount Controller", func() {
 	Context("When reconciling a ServiceAccount", func() {
 		var err error
 		ctx := context.Background()
 		cfg, err := config.NewConfig(
 			config.WithDockerConfigJSON(imagePullSecretData),
-			config.WithSecretNamespace("kube-system"),
+			config.WithSecretNamespace(kubeSystemNs),
 			config.WithFeatureDeletePods(true),
 		)
 		if err != nil {
@@ -254,7 +275,7 @@ var _ = Describe("ServiceAccount Controller", func() {
 		ctx := context.Background()
 		cfg, err := config.NewConfig(
 			config.WithDockerConfigJSON(imagePullSecretData),
-			config.WithSecretNamespace("kube-system"),
+			config.WithSecretNamespace(kubeSystemNs),
 		)
 		if err != nil {
 			panic(err)
@@ -279,42 +300,29 @@ var _ = Describe("ServiceAccount Controller", func() {
 			// In production, the manager's cache only watches secrets with the
 			// managed-by label. Pre-existing secrets without it are invisible
 			// to Get (returns NotFound) while still existing in the API server
-			// (Create returns AlreadyExists).
+			// (Create returns AlreadyExists). The raw (un-intercepted) client
+			// doubles as the uncached API reader.
 			testScheme := kruntime.NewScheme()
 			Expect(clientgoscheme.AddToScheme(testScheme)).NotTo(HaveOccurred())
 
-			labelFilteredClient := fake.NewClientBuilder().
+			rawClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithObjects(
 					namespace.DeepCopy(),
 					serviceAccount.DeepCopy(),
 					preExistingSecret,
 				).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-						if err := c.Get(ctx, key, obj, opts...); err != nil {
-							return err
-						}
-						// Simulate label-filtered cache: secrets without the
-						// managed-by label are invisible and appear as NotFound.
-						if secret, ok := obj.(*corev1.Secret); ok {
-							if secret.Labels[config.LabelManagedBy] != config.AnnotationAppName {
-								return apierrs.NewNotFound(
-									schema.GroupResource{Group: "", Resource: "secrets"},
-									key.Name,
-								)
-							}
-						}
-						return nil
-					},
-				}).
 				Build()
+			labelFilteredClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+				Get: unlabeledSecretsNotFound,
+			})
 
 			By("Reconciling the ServiceAccount with a pre-existing unlabeled secret")
 			reconciler := &ServiceAccountReconciler{
-				Client: labelFilteredClient,
-				Scheme: testScheme,
-				Config: cfg,
+				Client:    labelFilteredClient,
+				APIReader: rawClient,
+				Scheme:    testScheme,
+				Config:    cfg,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: serviceAccountNN,
@@ -347,7 +355,7 @@ var _ = Describe("ServiceAccount Controller", func() {
 		ctx := context.Background()
 		cfg, err := config.NewConfig(
 			config.WithDockerConfigJSON(imagePullSecretData),
-			config.WithSecretNamespace("kube-system"),
+			config.WithSecretNamespace(kubeSystemNs),
 		)
 		if err != nil {
 			panic(err)
@@ -403,6 +411,80 @@ var _ = Describe("ServiceAccount Controller", func() {
 
 			By("still ignoring delete events")
 			Expect(pred.Delete(event.DeleteEvent{Object: saIn("sa-predns-managed")})).To(BeFalse())
+		})
+	})
+
+	// Secret.type is immutable in Kubernetes. A pre-existing secret with the
+	// wrong type (e.g. Opaque) can never be merge-patched into a usable
+	// imagePullSecret, so it has to be deleted and recreated.
+	Context("When adopting a pre-existing secret with an incompatible type", func() {
+		ctx := context.Background()
+		cfg, err := config.NewConfig(
+			config.WithDockerConfigJSON(imagePullSecretData),
+			config.WithSecretNamespace(kubeSystemNs),
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		It("should delete and recreate the secret with the correct type", func() {
+			namespace, serviceAccount, serviceAccountNN, secretNN := makeObjects("testns-wrong-type", "default", cfg.SecretName)
+
+			preExistingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfg.SecretName,
+					Namespace: namespace.GetName(),
+				},
+				Data: map[string][]byte{
+					"some-key": []byte("some-value"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			}
+
+			testScheme := kruntime.NewScheme()
+			Expect(clientgoscheme.AddToScheme(testScheme)).NotTo(HaveOccurred())
+
+			rawClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(
+					namespace.DeepCopy(),
+					serviceAccount.DeepCopy(),
+					preExistingSecret,
+				).
+				Build()
+			labelFilteredClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+				Get: unlabeledSecretsNotFound,
+			})
+
+			By("Reconciling the ServiceAccount with a pre-existing wrong-type secret")
+			reconciler := &ServiceAccountReconciler{
+				Client:    labelFilteredClient,
+				APIReader: rawClient,
+				Scheme:    testScheme,
+				Config:    cfg,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: serviceAccountNN,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the secret was recreated with the dockerconfigjson type")
+			foundSecret := &corev1.Secret{}
+			Expect(rawClient.Get(ctx, secretNN, foundSecret)).To(Succeed())
+			Expect(foundSecret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+
+			By("Verifying the recreated secret carries the managed labels and annotations")
+			Expect(foundSecret.Labels).To(HaveKeyWithValue(config.LabelManagedBy, config.AnnotationAppName))
+			Expect(foundSecret.Annotations).To(HaveKeyWithValue(config.AnnotationManagedBy, config.AnnotationAppName))
+
+			By("Verifying the recreated secret contains the current credentials")
+			Expect(string(foundSecret.Data[corev1.DockerConfigJsonKey])).To(Equal(imagePullSecretData))
+
+			By("Verifying idempotency - second reconciliation succeeds without errors")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: serviceAccountNN,
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -213,7 +213,11 @@ func deletePodIfImagePullFailed(ctx context.Context, k8sClient client.Client, po
 	return nil
 }
 
-func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, c *config.Config, namespace string) (bool, error) {
+func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiReader client.Reader, c *config.Config, namespace string) (bool, error) {
+	if apiReader == nil {
+		apiReader = k8sClient
+	}
+
 	desiredSecret, err := ConstructImagePullSecret(c, namespace)
 	if err != nil {
 		return false, fmt.Errorf("failed to construct imagePullSecret: %v", err)
@@ -232,8 +236,8 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, c *c
 			if err := k8sClient.Create(ctx, desiredSecret); err != nil {
 				if apierrs.IsAlreadyExists(err) {
 					// Secret exists but is not in the label-filtered cache (e.g., pre-existing
-					// installation without the managed-by label). Patch it to adopt ownership.
-					return patchUnmanagedSecret(ctx, k8sClient, desiredSecret)
+					// installation without the managed-by label). Adopt it.
+					return adoptExistingSecret(ctx, k8sClient, apiReader, desiredSecret)
 				}
 				return false, fmt.Errorf("failed to create Secret: %v", err)
 			}
@@ -285,6 +289,36 @@ func enforceMapEntries(current map[string]string, desired map[string]string) (ma
 		}
 	}
 	return merged, changed
+}
+
+// adoptExistingSecret handles Create conflicts for secrets that exist in the
+// cluster but are invisible to the label-filtered cache (e.g. pre-existing
+// installations without the managed-by label). The live secret is fetched via
+// the uncached apiReader. Secrets of the correct type are adopted in place via
+// merge patch. Secret.type is immutable in Kubernetes, so a secret of any
+// other type can never serve as imagePullSecret and is deleted and recreated.
+func adoptExistingSecret(ctx context.Context, k8sClient client.Client, apiReader client.Reader, desiredSecret *corev1.Secret) (bool, error) {
+	live := &corev1.Secret{}
+	if err := apiReader.Get(ctx, client.ObjectKeyFromObject(desiredSecret), live); err != nil {
+		return false, fmt.Errorf("failed to fetch pre-existing Secret: %v", err)
+	}
+
+	if live.Type == corev1.SecretTypeDockerConfigJson {
+		return patchUnmanagedSecret(ctx, k8sClient, desiredSecret)
+	}
+
+	log.FromContext(ctx).Info("Recreating pre-existing Secret with incompatible type",
+		"name", live.GetName(),
+		"namespace", live.GetNamespace(),
+		"type", string(live.Type),
+	)
+	if err := k8sClient.Delete(ctx, live, client.Preconditions{UID: &live.UID}); err != nil {
+		return false, fmt.Errorf("failed to delete pre-existing Secret with incompatible type: %v", err)
+	}
+	if err := k8sClient.Create(ctx, desiredSecret.DeepCopy()); err != nil {
+		return false, fmt.Errorf("failed to recreate Secret: %v", err)
+	}
+	return true, nil
 }
 
 // patchUnmanagedSecret patches an existing secret that is not in the label-filtered cache.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -588,7 +588,7 @@ func newReconcileTestConfig(t *testing.T) *config.Config {
 	return cfg
 }
 
-func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+func newFakeClient(t *testing.T, objs ...client.Object) client.WithWatch {
 	t.Helper()
 	scheme := kruntime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
@@ -728,8 +728,8 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 			}
 			k8sClient := newFakeClient(t, objs...)
 
-			// Act
-			changed, err := ReconcileImagePullSecret(context.Background(), k8sClient, cfg, nsDefault)
+			// Act (nil apiReader exercises the fallback to k8sClient)
+			changed, err := ReconcileImagePullSecret(context.Background(), k8sClient, nil, cfg, nsDefault)
 
 			// Assert
 			if err != nil {
@@ -745,6 +745,111 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 			}
 			if tt.assert != nil {
 				tt.assert(t, cfg, got)
+			}
+		})
+	}
+}
+
+// Test_ReconcileImagePullSecret_AdoptsPreExistingSecrets covers the
+// Create->AlreadyExists path: the pre-existing secret is invisible to the
+// label-filtered cache (Get is intercepted to return NotFound for unlabeled
+// secrets), but Create against the API server fails with AlreadyExists. The
+// raw (un-intercepted) client acts as the uncached API reader.
+func Test_ReconcileImagePullSecret_AdoptsPreExistingSecrets(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingType corev1.SecretType
+		wantDeletes  int
+	}{
+		{
+			name:         "adopts a compatible pre-existing secret via patch without deleting it",
+			existingType: corev1.SecretTypeDockerConfigJson,
+			wantDeletes:  0,
+		},
+		{
+			name:         "deletes and recreates a pre-existing secret with incompatible type",
+			existingType: corev1.SecretTypeOpaque,
+			wantDeletes:  1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			cfg := newReconcileTestConfig(t)
+			preExisting := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfg.SecretName,
+					Namespace: nsDefault,
+					Annotations: map[string]string{
+						foreignAnnotationKey: foreignAnnotationValue,
+					},
+				},
+				Data: map[string][]byte{
+					"some-key": []byte("some-value"),
+				},
+				Type: tt.existingType,
+			}
+			rawClient := newFakeClient(t, preExisting)
+
+			deleteCalls := 0
+			labelFilteredClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey,
+					obj client.Object, opts ...client.GetOption) error {
+					if err := c.Get(ctx, key, obj, opts...); err != nil {
+						return err
+					}
+					if secret, ok := obj.(*corev1.Secret); ok {
+						if secret.Labels[config.LabelManagedBy] != config.AnnotationAppName {
+							return apierrs.NewNotFound(
+								schema.GroupResource{Group: "", Resource: "secrets"},
+								key.Name,
+							)
+						}
+					}
+					return nil
+				},
+				Delete: func(ctx context.Context, c client.WithWatch,
+					obj client.Object, opts ...client.DeleteOption) error {
+					deleteCalls++
+					return c.Delete(ctx, obj, opts...)
+				},
+			})
+
+			// Act
+			changed, err := ReconcileImagePullSecret(context.Background(), labelFilteredClient, rawClient, cfg, nsDefault)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("ReconcileImagePullSecret() error = %v", err)
+			}
+			if !changed {
+				t.Errorf("ReconcileImagePullSecret() changed = false, want true")
+			}
+			if deleteCalls != tt.wantDeletes {
+				t.Errorf("delete calls = %d, want %d", deleteCalls, tt.wantDeletes)
+			}
+
+			got := &corev1.Secret{}
+			if err := rawClient.Get(context.Background(),
+				types.NamespacedName{Name: cfg.SecretName, Namespace: nsDefault}, got); err != nil {
+				t.Fatalf("failed to fetch reconciled Secret: %v", err)
+			}
+			if got.Type != corev1.SecretTypeDockerConfigJson {
+				t.Errorf("secret type = %q, want %q", got.Type, corev1.SecretTypeDockerConfigJson)
+			}
+			if data := string(got.Data[corev1.DockerConfigJsonKey]); data != reconcileDockerCfgJSON {
+				t.Errorf("secret data = %q, want %q", data, reconcileDockerCfgJSON)
+			}
+			if got.Labels[config.LabelManagedBy] != config.AnnotationAppName {
+				t.Errorf("managed-by label = %q, want %q", got.Labels[config.LabelManagedBy], config.AnnotationAppName)
+			}
+			if got.Annotations[config.AnnotationManagedBy] != config.AnnotationAppName {
+				t.Errorf("managed-by annotation = %q, want %q",
+					got.Annotations[config.AnnotationManagedBy], config.AnnotationAppName)
+			}
+			if tt.wantDeletes == 0 && got.Annotations[foreignAnnotationKey] != foreignAnnotationValue {
+				t.Errorf("foreign annotation = %q, want %q (adoption must not drop foreign annotations)",
+					got.Annotations[foreignAnnotationKey], foreignAnnotationValue)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- On `Create` → `AlreadyExists` (label-filtered cache miss), adoption merge-patched data into the live secret regardless of its `Type`. `Secret.type` is immutable — a pre-existing `Opaque` secret stayed silently unusable as an imagePullSecret.
- Both reconcilers now carry an `APIReader` (uncached `mgr.GetAPIReader()`, wired in `cmd/main.go`) used to read the live secret on the adoption path: correct type → merge-patch as before; wrong type → delete with UID precondition + recreate with the correct type. Brief windowless trade-off (no imagePullSecret during recreate) was explicitly approved.

## Test plan
- [x] Ginkgo: pre-existing `Opaque` secret (invisible to the label-filtered cache) is deleted and recreated as `kubernetes.io/dockerconfigjson` with managed labels/annotations and current credentials; idempotent on re-reconcile
- [x] Utils table: right-type secret adopted via patch (0 deletes, foreign annotation survives); wrong-type → 1 delete + recreate
- [ ] CI workflows green

Stacked on #210/#211. Implemented by a sub-agent in an isolated worktree; integrated against current master.