### PR TITLE
fix(controller): run dockerconfigjson file watcher as manager runnable

### DIFF
--- a/internal/controller/dockerconfig_watcher.go
+++ b/internal/controller/dockerconfig_watcher.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/tamcore/imagepullsecret-patcher/internal/config"
+	"github.com/tamcore/imagepullsecret-patcher/internal/utils"
+)
+
+const (
+	// watcherEventBuffer sizes the event channel so reconcile bursts after a
+	// file change do not block the watcher loop.
+	watcherEventBuffer = 64
+	// watcherRetryBackoff is how long to wait before retrying after a failed
+	// initial stat of the watched file. Kubelet refreshes mounted files via
+	// atomic symlink swaps, which can briefly race with the stat.
+	watcherRetryBackoff = 5 * time.Second
+)
+
+// DockerConfigWatcher is a manager runnable that polls the configured
+// dockerconfigjson file for changes and emits a GenericEvent for every
+// managed Secret when it changes, triggering their reconciliation.
+type DockerConfigWatcher struct {
+	Client client.Client
+	Config *config.Config
+	Events chan event.GenericEvent
+}
+
+// NeedLeaderElection ensures the watcher only runs on the elected leader.
+func (w *DockerConfigWatcher) NeedLeaderElection() bool { return true }
+
+// Start implements manager.Runnable. It blocks until the context is
+// cancelled, returning nil for a clean shutdown.
+func (w *DockerConfigWatcher) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	logger.Info("starting dockerconfigjson file watcher", "path", w.Config.DockerConfigJSONPath)
+
+	for {
+		if err := utils.WaitUntilFileChanges(ctx, w.Config.DockerConfigJSONPath); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			logger.Error(err, "failed to watch dockerconfigjson file, retrying", "path", w.Config.DockerConfigJSONPath)
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(watcherRetryBackoff):
+			}
+			continue
+		}
+
+		if stopped := w.notifyManagedSecrets(ctx); stopped {
+			return nil
+		}
+	}
+}
+
+// notifyManagedSecrets sends a GenericEvent for every managed Secret. It
+// returns true when the context was cancelled while sending events.
+func (w *DockerConfigWatcher) notifyManagedSecrets(ctx context.Context) bool {
+	logger := log.FromContext(ctx)
+
+	// Fetch managed Secrets using the cached client (which respects the label
+	// selector). This avoids listing ALL secrets cluster-wide.
+	secretList := &corev1.SecretList{}
+	if err := w.Client.List(ctx, secretList, client.MatchingLabels{
+		config.LabelManagedBy: config.AnnotationAppName,
+	}); err != nil {
+		logger.Error(err, "error listing secrets")
+		return false
+	}
+
+	for _, d := range secretList.Items {
+		secret := d
+		ns, err := utils.FetchNamespace(ctx, w.Client, secret.GetNamespace())
+		if err != nil {
+			logger.Error(err, "error fetching namespace", "namespace", secret.GetNamespace())
+			continue
+		}
+		if !utils.IsManagedSecret(w.Config, ns, &secret) {
+			continue
+		}
+		select {
+		case w.Events <- event.GenericEvent{Object: &secret}:
+		case <-ctx.Done():
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/controller/dockerconfig_watcher_test.go
+++ b/internal/controller/dockerconfig_watcher_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/tamcore/imagepullsecret-patcher/internal/config"
+)
+
+const (
+	watcherTestNamespace  = "watched-ns"
+	watcherTestSecretNs   = "kube-system"
+	watcherTestSecretName = "global-imagepullsecret"
+	watcherTestTimeout    = 10 * time.Second
+	watcherTestPoll       = 200 * time.Millisecond
+)
+
+var _ = Describe("DockerConfigWatcher", func() {
+	It("requires leader election so only the leader polls the file", func() {
+		watcher := &DockerConfigWatcher{}
+		Expect(watcher.NeedLeaderElection()).To(BeTrue())
+	})
+
+	It("emits events for managed secrets when the watched file changes and stops cleanly on context cancellation", func() {
+		By("building a fake client with a namespace and a managed secret")
+		scheme := kruntime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: watcherTestNamespace,
+			},
+		}
+		managedSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      watcherTestSecretName,
+				Namespace: watcherTestNamespace,
+				Labels: map[string]string{
+					config.LabelManagedBy: config.AnnotationAppName,
+				},
+				Annotations: map[string]string{
+					config.AnnotationManagedBy: config.AnnotationAppName,
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(namespace, managedSecret).
+			Build()
+
+		By("writing a valid dockerconfigjson file to watch")
+		tmpfile := filepath.Join(GinkgoT().TempDir(), "dockerconfig.json")
+		Expect(os.WriteFile(tmpfile, []byte(`{"auths":{}}`), 0o600)).To(Succeed())
+
+		cfg, err := config.NewConfig(
+			config.WithDockerConfigJSONPath(tmpfile),
+			config.WithSecretNamespace(watcherTestSecretNs),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		events := make(chan event.GenericEvent, watcherEventBuffer)
+		watcher := &DockerConfigWatcher{
+			Client: fakeClient,
+			Config: cfg,
+			Events: events,
+		}
+
+		By("starting the watcher with a cancellable context")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		startResult := make(chan error, 1)
+		go func() {
+			defer GinkgoRecover()
+			startResult <- watcher.Start(ctx)
+		}()
+
+		By("touching the watched file until an event for the managed secret arrives")
+		var received event.GenericEvent
+		Eventually(func() bool {
+			now := time.Now()
+			Expect(os.Chtimes(tmpfile, now, now)).To(Succeed())
+			select {
+			case received = <-events:
+				return true
+			default:
+				return false
+			}
+		}, watcherTestTimeout, watcherTestPoll).Should(BeTrue())
+
+		Expect(received.Object.GetName()).To(Equal(watcherTestSecretName))
+		Expect(received.Object.GetNamespace()).To(Equal(watcherTestNamespace))
+
+		By("cancelling the context and expecting Start to return nil")
+		cancel()
+		Eventually(startResult, watcherTestTimeout).Should(Receive(BeNil()))
+	})
+})

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -94,54 +94,23 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	ctx := context.TODO()
-
 	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("SecretController").
 		For(&corev1.Secret{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		WithEventFilter(r.managedPredicate())
 
-	// If DockerConfigJSONPath is defined
+	// If DockerConfigJSONPath is defined, watch it for changes through a
+	// manager runnable. The manager hands the watcher its own context (clean
+	// shutdown) and gates it behind leader election (only the leader polls).
 	if r.Config.DockerConfigJSONPath != "" && r.Config.FeatureWatchDockerConfigJSONPath {
-		// Create a GenericEvent channel, to pass reconcile events to the controller
-		secretRconciliationSourceChannel := make(chan event.GenericEvent)
-
-		// Set up a goroutine, which does a basic polling watch on DockerConfigJSONPath
-		go func(ctx context.Context) {
-			log.FromContext(ctx).Info("setting up watcher")
-
-			for {
-				// Wait, until DockerConfigJSONPath has changed
-				utils.WaitUntilFileChanges(r.Config.DockerConfigJSONPath)
-
-				// Fetch managed Secrets using the cached client (which respects the label selector).
-				// This avoids listing ALL secrets cluster-wide, reducing etcd load significantly.
-				secretList := &corev1.SecretList{}
-				if err := r.List(ctx, secretList, client.MatchingLabels{
-					config.LabelManagedBy: config.AnnotationAppName,
-				}); err != nil {
-					log.FromContext(ctx).Error(err, "error listing secrets")
-					continue
-				}
-
-				for _, d := range secretList.Items {
-					ns, err := utils.FetchNamespace(ctx, r.Client, d.GetNamespace())
-					if err != nil {
-						log.FromContext(ctx).Error(err, "error fetching namespace")
-						continue
-					}
-					// Filter for Secrets that are actually managed
-					if utils.IsManagedSecret(r.Config, ns, &d) {
-						// Send reconcile event for fetched Secret
-						secretRconciliationSourceChannel <- event.GenericEvent{Object: &d}
-					}
-				}
-			}
-		}(ctx)
+		events := make(chan event.GenericEvent, watcherEventBuffer)
+		if err := mgr.Add(&DockerConfigWatcher{Client: r.Client, Config: r.Config, Events: events}); err != nil {
+			return err
+		}
 
 		// Attach channel event source to controller
-		builder = builder.WatchesRawSource(source.Channel(secretRconciliationSourceChannel, &handler.EnqueueRequestForObject{}))
+		builder = builder.WatchesRawSource(source.Channel(events, &handler.EnqueueRequestForObject{}))
 	}
 
 	return builder.Complete(r)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -392,17 +392,34 @@ func GetDockerConfigJSON(c *config.Config) (string, error) {
 	return string(b), nil
 }
 
-func WaitUntilFileChanges(filename string) {
-	initialStat, _ := os.Stat(filename)
+// fileWatchPollInterval is how often the watched file is polled for changes.
+const fileWatchPollInterval = 1 * time.Second
+
+// WaitUntilFileChanges blocks until the modification time of filename changes.
+// It returns nil once a change is detected, ctx.Err() when the context is
+// cancelled, or a wrapped error if the file cannot be stat'ed initially.
+func WaitUntilFileChanges(ctx context.Context, filename string) error {
+	initialStat, err := os.Stat(filename)
+	if err != nil {
+		return fmt.Errorf("failed to stat watched file %q: %w", filename, err)
+	}
+
+	ticker := time.NewTicker(fileWatchPollInterval)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(1 * time.Second)
-		stat, err := os.Stat(filename)
-		if err != nil {
-			fmt.Println("Error:", err)
-			continue
-		}
-		if stat.ModTime() != initialStat.ModTime() {
-			return
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			stat, err := os.Stat(filename)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "failed to stat watched file", "path", filename)
+				continue
+			}
+			if !stat.ModTime().Equal(initialStat.ModTime()) {
+				return nil
+			}
 		}
 	}
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -18,10 +18,12 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -853,4 +855,86 @@ func Test_ReconcileImagePullSecret_AdoptsPreExistingSecrets(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_WaitUntilFileChanges(t *testing.T) {
+	const (
+		modifyDelay  = 200 * time.Millisecond
+		cancelDelay  = 100 * time.Millisecond
+		returnWithin = 2 * time.Second
+		watchTimeout = 3 * time.Second
+	)
+
+	writeWatchedFile := func(t *testing.T) string {
+		t.Helper()
+		filename := filepath.Join(t.TempDir(), "dockerconfig.json")
+		if err := os.WriteFile(filename, []byte(`{"auths":{}}`), 0o600); err != nil {
+			t.Fatalf("failed to write watched file: %v", err)
+		}
+		return filename
+	}
+
+	t.Run("returns error promptly when file is missing instead of panicking", func(t *testing.T) {
+		// Arrange
+		missingFile := filepath.Join(t.TempDir(), "missing.json")
+
+		// Act
+		err := WaitUntilFileChanges(context.Background(), missingFile)
+
+		// Assert
+		if err == nil {
+			t.Fatal("WaitUntilFileChanges() expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("returns ctx.Err() when context is cancelled and file never changes", func(t *testing.T) {
+		// Arrange
+		filename := writeWatchedFile(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		timer := time.AfterFunc(cancelDelay, cancel)
+		defer timer.Stop()
+		defer cancel()
+
+		// Act
+		done := make(chan error, 1)
+		go func() { done <- WaitUntilFileChanges(ctx, filename) }()
+
+		// Assert
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("WaitUntilFileChanges() error = %v, want context.Canceled", err)
+			}
+		case <-time.After(returnWithin):
+			t.Fatal("WaitUntilFileChanges() did not return within 2s after context cancellation")
+		}
+	})
+
+	t.Run("returns nil when file modification time changes", func(t *testing.T) {
+		// Arrange
+		filename := writeWatchedFile(t)
+		ctx, cancel := context.WithTimeout(context.Background(), watchTimeout)
+		defer cancel()
+
+		// Act
+		done := make(chan error, 1)
+		go func() { done <- WaitUntilFileChanges(ctx, filename) }()
+		bump := time.AfterFunc(modifyDelay, func() {
+			futureTime := time.Now().Add(time.Hour)
+			if err := os.Chtimes(filename, futureTime, futureTime); err != nil {
+				t.Errorf("failed to change file modification time: %v", err)
+			}
+		})
+		defer bump.Stop()
+
+		// Assert
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("WaitUntilFileChanges() error = %v, want nil", err)
+			}
+		case <-time.After(watchTimeout):
+			t.Fatal("WaitUntilFileChanges() did not detect the file change in time")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Fixes nil dereference panic in `WaitUntilFileChanges` when the watched file is missing at startup
- Replaces unbuffered channel and uncontrolled goroutine with a proper `DockerConfigWatcher` manager Runnable (`NeedLeaderElection() = true`)
- `WaitUntilFileChanges` now takes `ctx context.Context` and returns `error`; context cancellation stops the watch cleanly
- Buffered event channel (64) prevents blocking on shutdown

## Test plan
- [ ] `Test_WaitUntilFileChanges`: missing file returns error (not panic); cancel returns ctx.Err(); file touch returns nil
- [ ] `dockerconfig_watcher_test.go`: event arrives after file change; Start returns nil on cancel; NeedLeaderElection == true
- [ ] CI green