### PR TITLE
feat(controller): reconcile serviceaccounts when namespace exclusion changes

### DIFF
--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -20,21 +20,30 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/tamcore/imagepullsecret-patcher/internal/config"
 	"github.com/tamcore/imagepullsecret-patcher/internal/utils"
 )
+
+// globMetacharacters are the filepath.Match metacharacters supported by
+// utils.IsStringInList. Config entries containing any of them are globs.
+const globMetacharacters = "*?["
 
 // namespaceCacheRetryDelay is how long to wait before retrying when an
 // object's namespace is not yet visible in the informer cache (e.g. a
@@ -114,13 +123,89 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 // SetupWithManager sets up the controller with the Manager.
+//
+// Predicates are attached per-watch instead of via WithEventFilter, because
+// an event filter would apply to the Namespace watch as well: managedPredicate
+// treats the event object as a ServiceAccount and would look up the namespace
+// OF the namespace object (empty for cluster-scoped objects), breaking it.
 func (r *ServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("ServiceAccountController").
-		For(&corev1.ServiceAccount{}).
+		For(&corev1.ServiceAccount{}, ctrlbuilder.WithPredicates(r.managedPredicate())).
+		Watches(&corev1.Namespace{},
+			handler.EnqueueRequestsFromMapFunc(r.namespaceToServiceAccounts),
+			ctrlbuilder.WithPredicates(namespaceTransitionPredicate(r.Config))).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
-		WithEventFilter(r.managedPredicate()).
 		Complete(r)
+}
+
+// namespaceToServiceAccounts maps a Namespace event to reconcile requests for
+// every configured ServiceAccount in that namespace. Excluded namespaces map
+// to nothing: only newly-included namespaces need reconciliation, as we never
+// detach from newly-excluded ones (matching current behavior).
+func (r *ServiceAccountReconciler) namespaceToServiceAccounts(ctx context.Context, obj client.Object) []reconcile.Request {
+	if utils.IsNamespaceExcluded(r.Config, obj) {
+		return nil
+	}
+
+	seen := map[types.NamespacedName]struct{}{}
+	var requests []reconcile.Request
+	enqueue := func(name string) {
+		nn := types.NamespacedName{Namespace: obj.GetName(), Name: name}
+		if _, isDuplicate := seen[nn]; isDuplicate {
+			return
+		}
+		seen[nn] = struct{}{}
+		requests = append(requests, reconcile.Request{NamespacedName: nn})
+	}
+
+	hasGlobEntry := false
+	for _, entry := range strings.Split(r.Config.ServiceAccounts, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if strings.ContainsAny(entry, globMetacharacters) {
+			hasGlobEntry = true
+			continue
+		}
+		enqueue(entry)
+	}
+
+	if !hasGlobEntry {
+		return requests
+	}
+
+	// Glob entries can't be enqueued directly; list the ServiceAccounts in
+	// the namespace and enqueue every one matching the configured list.
+	saList := &corev1.ServiceAccountList{}
+	if err := r.List(ctx, saList, client.InNamespace(obj.GetName())); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list ServiceAccounts while mapping namespace event",
+			"namespace", obj.GetName())
+		return requests
+	}
+	for _, sa := range saList.Items {
+		if utils.IsStringInList(sa.GetName(), r.Config.ServiceAccounts) {
+			enqueue(sa.GetName())
+		}
+	}
+
+	return requests
+}
+
+// namespaceTransitionPredicate only lets Namespace updates through when the
+// exclusion state changes, so periodic resync churn doesn't flood the
+// workqueue. Create events are dropped because ServiceAccount create events
+// already cover brand-new namespaces.
+func namespaceTransitionPredicate(c *config.Config) predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return utils.IsNamespaceExcluded(c, e.ObjectOld) != utils.IsNamespaceExcluded(c, e.ObjectNew)
+		},
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
 }
 
 // managedPredicate filters events down to ServiceAccounts this controller

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -487,4 +487,145 @@ var _ = Describe("ServiceAccount Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	Context("When a namespace exclusion changes", func() {
+		ctx := context.Background()
+		cfg, err := config.NewConfig(
+			config.WithDockerConfigJSON(imagePullSecretData),
+			config.WithSecretNamespace(kubeSystemNs),
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		newFakeClient := func(objs ...client.Object) client.Client {
+			scheme := kruntime.NewScheme()
+			Expect(clientgoscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+			return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+		}
+
+		namespaceNamed := func(name string, annotations map[string]string) *corev1.Namespace {
+			return &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			}
+		}
+
+		serviceAccountIn := func(namespace string, name string) *corev1.ServiceAccount {
+			return &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			}
+		}
+
+		requestFor := func(namespace string, name string) reconcile.Request {
+			return reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
+			}
+		}
+
+		Describe("namespaceToServiceAccounts", func() {
+			It("returns exactly one request for the default ServiceAccount in a managed namespace", func() {
+				nsName := "mapns-managed"
+				c := newFakeClient()
+				reconciler := &ServiceAccountReconciler{Client: c, Scheme: c.Scheme(), Config: cfg}
+
+				requests := reconciler.namespaceToServiceAccounts(ctx, namespaceNamed(nsName, nil))
+
+				Expect(requests).To(ConsistOf(requestFor(nsName, saDefault)))
+			})
+
+			It("returns no requests for an excluded namespace", func() {
+				c := newFakeClient()
+				reconciler := &ServiceAccountReconciler{Client: c, Scheme: c.Scheme(), Config: cfg}
+				excludedNs := namespaceNamed("mapns-excluded", map[string]string{
+					cfg.ExcludeAnnotation: annotationTrue,
+				})
+
+				Expect(reconciler.namespaceToServiceAccounts(ctx, excludedNs)).To(BeEmpty())
+			})
+
+			It("expands glob entries to matching ServiceAccounts and de-duplicates requests", func() {
+				nsName := "mapns-glob"
+				globCfg, err := config.NewConfig(
+					config.WithDockerConfigJSON(imagePullSecretData),
+					config.WithSecretNamespace(kubeSystemNs),
+					config.WithServiceAccounts("build*,default"),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c := newFakeClient(
+					serviceAccountIn(nsName, "build-a"),
+					serviceAccountIn(nsName, "build-b"),
+					serviceAccountIn(nsName, "other"),
+				)
+				reconciler := &ServiceAccountReconciler{Client: c, Scheme: c.Scheme(), Config: globCfg}
+
+				requests := reconciler.namespaceToServiceAccounts(ctx, namespaceNamed(nsName, nil))
+
+				Expect(requests).To(ConsistOf(
+					requestFor(nsName, "build-a"),
+					requestFor(nsName, "build-b"),
+					requestFor(nsName, saDefault),
+				))
+			})
+		})
+
+		Describe("namespaceTransitionPredicate", func() {
+			It("only passes updates that change the exclusion state", func() {
+				pred := namespaceTransitionPredicate(cfg)
+				included := namespaceNamed("transns", nil)
+				excluded := namespaceNamed("transns", map[string]string{
+					cfg.ExcludeAnnotation: annotationTrue,
+				})
+				relabeled := namespaceNamed("transns", nil)
+				relabeled.Labels = map[string]string{"team": "platform"}
+
+				By("passing updates that add the exclude annotation")
+				Expect(pred.Update(event.UpdateEvent{ObjectOld: included, ObjectNew: excluded})).To(BeTrue())
+
+				By("passing updates that remove the exclude annotation")
+				Expect(pred.Update(event.UpdateEvent{ObjectOld: excluded, ObjectNew: included})).To(BeTrue())
+
+				By("dropping unrelated label churn with unchanged exclusion state")
+				Expect(pred.Update(event.UpdateEvent{ObjectOld: included, ObjectNew: relabeled})).To(BeFalse())
+
+				By("dropping create events, as ServiceAccount creates already cover new namespaces")
+				Expect(pred.Create(event.CreateEvent{Object: included})).To(BeFalse())
+			})
+		})
+
+		It("reconciles the default ServiceAccount once the exclude annotation is removed", func() {
+			nsName := "mapns-unexcluded"
+			excludedNs := namespaceNamed(nsName, map[string]string{
+				cfg.ExcludeAnnotation: annotationTrue,
+			})
+			c := newFakeClient(excludedNs, serviceAccountIn(nsName, saDefault))
+			reconciler := &ServiceAccountReconciler{Client: c, Scheme: c.Scheme(), Config: cfg}
+
+			By("producing no requests while the namespace is still excluded")
+			Expect(reconciler.namespaceToServiceAccounts(ctx, excludedNs)).To(BeEmpty())
+
+			By("removing the exclude annotation from the namespace")
+			includedNs := excludedNs.DeepCopy()
+			includedNs.Annotations = nil
+			Expect(c.Update(ctx, includedNs)).To(Succeed())
+
+			By("mapping the now-included namespace to exactly one request")
+			requests := reconciler.namespaceToServiceAccounts(ctx, includedNs)
+			Expect(requests).To(ConsistOf(requestFor(nsName, saDefault)))
+
+			By("reconciling the mapped request")
+			_, err := reconciler.Reconcile(ctx, requests[0])
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the imagePullSecret was created with the expected data")
+			foundSecret := &corev1.Secret{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: cfg.SecretName, Namespace: nsName}, foundSecret)).To(Succeed())
+			Expect(string(foundSecret.Data[corev1.DockerConfigJsonKey])).To(Equal(imagePullSecretData))
+
+			By("verifying the ServiceAccount was patched with the imagePullSecret reference")
+			foundSA := &corev1.ServiceAccount{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: saDefault, Namespace: nsName}, foundSA)).To(Succeed())
+			Expect(foundSA.ImagePullSecrets).To(ContainElement(corev1.LocalObjectReference{Name: cfg.SecretName}))
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- Adds Namespace watch to the ServiceAccount controller so removing an exclude annotation triggers immediate reconciliation (previously required up to ~10h for a resync)
- `namespaceToServiceAccounts` mapper: excluded → nil; exact SA name → direct request; glob entries → List+filter+dedupe
- `namespaceTransitionPredicate`: only fires on actual exclusion-state change (not on label churn); Create/Delete/Generic → false

## Test plan
- [ ] `namespaceToServiceAccounts`: managed namespace, excluded namespace, glob expansion with dedup
- [ ] `namespaceTransitionPredicate`: add/remove annotation fires; unrelated label change does not; create does not
- [ ] E2E: annotation removed → request produced → secret created + SA patched
- [ ] CI green