### PR TITLE
refactor(utils): wrap errors with %w and use structured logging

### DIFF
--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -75,10 +75,10 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("Reconciling imagePullSecret in " + req.Namespace)
+	log.Info("Reconciling imagePullSecret", "namespace", req.Namespace)
 	doPatch := false
 	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, req.Namespace); err != nil {
-		return ctrl.Result{}, fmt.Errorf("Failed to reconcile imagePullSecret in Namespace '"+req.Namespace+"': %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile imagePullSecret in namespace %q: %w", req.Namespace, err)
 	} else {
 		doPatch = didPatch
 	}

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -75,7 +75,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		log.Error(err, "Failed to get ServiceAccount")
+		log.Error(err, "failed to get ServiceAccount")
 		return ctrl.Result{}, err
 	}
 
@@ -96,7 +96,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Ensure imagePullSecret exists before we attach it to the ServiceAccount
 	if _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, serviceAccount.GetNamespace()); err != nil {
-		return ctrl.Result{}, fmt.Errorf("Failed to reconcile imagePullSecret in Namespace '"+serviceAccount.GetNamespace()+"': %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile imagePullSecret in namespace %q: %w", serviceAccount.GetNamespace(), err)
 	}
 
 	patchFrom := client.MergeFrom(serviceAccount.DeepCopy())
@@ -108,14 +108,14 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, fmt.Errorf("failed to patch ImagePullSecret to ServiceAccount %s in namespace %s: %w",
 				serviceAccount.GetName(), serviceAccount.GetNamespace(), err)
 		}
-		log.Info("Attached ImagePullSecret to ServiceAccount '" + serviceAccount.GetName() + "' in namespace '" + serviceAccount.GetNamespace() + "'")
+		log.Info("Attached ImagePullSecret to ServiceAccount", "serviceaccount", serviceAccount.GetName(), "namespace", serviceAccount.GetNamespace())
 
 		if r.Config.FeatureDeletePods {
 			// Run Pod cleanup only if we're freshly attaching the imagePullSecret to the ServiceAccount
 			if err = utils.CleanupPodsForSA(ctx, r.Client, serviceAccount.GetNamespace(), serviceAccount.GetName()); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to cleanup Pods in unauthorized state: %w", err)
 			}
-			log.Info("Cleaned up Pods belonging to ServiceAccount " + serviceAccount.GetName())
+			log.Info("Cleaned up Pods belonging to ServiceAccount", "serviceaccount", serviceAccount.GetName(), "namespace", serviceAccount.GetNamespace())
 		}
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -220,7 +220,7 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiR
 
 	desiredSecret, err := ConstructImagePullSecret(c, namespace)
 	if err != nil {
-		return false, fmt.Errorf("failed to construct imagePullSecret: %v", err)
+		return false, fmt.Errorf("failed to construct imagePullSecret: %w", err)
 	}
 
 	secret := &corev1.Secret{}
@@ -239,11 +239,11 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiR
 					// installation without the managed-by label). Adopt it.
 					return adoptExistingSecret(ctx, k8sClient, apiReader, desiredSecret)
 				}
-				return false, fmt.Errorf("failed to create Secret: %v", err)
+				return false, fmt.Errorf("failed to create Secret: %w", err)
 			}
 			return true, nil
 		}
-		return false, fmt.Errorf("while fetching Secret: %v", err)
+		return false, fmt.Errorf("failed to fetch Secret: %w", err)
 	}
 
 	patchFrom := client.MergeFrom(secret.DeepCopy())
@@ -265,7 +265,7 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiR
 
 	if doPatch {
 		if err = k8sClient.Patch(ctx, secret, patchFrom); err != nil {
-			return false, fmt.Errorf("error while patching Secret '"+desiredSecret.GetName()+"' in namespace '"+desiredSecret.GetNamespace()+"': %v", err)
+			return false, fmt.Errorf("failed to patch Secret %q in namespace %q: %w", desiredSecret.GetName(), desiredSecret.GetNamespace(), err)
 		}
 	}
 	return doPatch, nil
@@ -332,7 +332,7 @@ func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredS
 		"data": desiredSecret.Data,
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed to marshal patch: %v", err)
+		return false, fmt.Errorf("failed to marshal patch: %w", err)
 	}
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -341,7 +341,7 @@ func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredS
 		},
 	}
 	if err := k8sClient.Patch(ctx, target, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
-		return false, fmt.Errorf("failed to patch existing Secret: %v", err)
+		return false, fmt.Errorf("failed to patch existing Secret: %w", err)
 	}
 	return true, nil
 }
@@ -349,7 +349,7 @@ func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredS
 func ConstructImagePullSecret(c *config.Config, namespace string) (*corev1.Secret, error) {
 	dockerConfigJSON, err := GetDockerConfigJSON(c)
 	if err != nil {
-		return nil, fmt.Errorf("error while reading dockerConfigJSON from filesystem: %v", err)
+		return nil, fmt.Errorf("failed to read dockerConfigJSON: %w", err)
 	}
 
 	secret := &corev1.Secret{

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -938,3 +938,33 @@ func Test_WaitUntilFileChanges(t *testing.T) {
 		}
 	})
 }
+
+func Test_ReconcileImagePullSecret_WrapsGetError(t *testing.T) {
+	// Arrange
+	sentinelErr := errors.New("sentinel get failure")
+	k8sClient := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return sentinelErr
+			},
+		}).
+		Build()
+	cfg := &config.Config{
+		SecretName:       "image-pull-secret",
+		DockerConfigJSON: `{"auths":{}}`,
+	}
+
+	// Act
+	_, err := ReconcileImagePullSecret(context.Background(), k8sClient, nil, cfg, nsDefault)
+
+	// Assert
+	if err == nil {
+		t.Fatal("ReconcileImagePullSecret() expected error, got nil")
+	}
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("ReconcileImagePullSecret() error does not wrap sentinel error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to fetch Secret") {
+		t.Errorf("ReconcileImagePullSecret() error = %v, want it to contain %q", err, "failed to fetch Secret")
+	}
+}


### PR DESCRIPTION
## Summary
- `%v` → `%w` throughout utils.go so errors can be inspected with `errors.Is`/`errors.As` by callers
- String-concat log lines → structured key/value pairs in both controllers
- Lowercase capitalized error strings in controllers

## Test plan
- [ ] `Test_ReconcileImagePullSecret_WrapsGetError`: verifies `errors.Is` works through the chain
- [ ] CI green