### PR TITLE
feat: emit Kubernetes Events on reconcile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -213,6 +213,10 @@ func main() {
 		APIReader: mgr.GetAPIReader(),
 		Scheme:    mgr.GetScheme(),
 		Config:    controllerConfig,
+		// The old (record) events API is sufficient here; the new events API
+		// would force an "action" verb we don't need. controller-runtime itself
+		// still exercises this call, suppressing the same deprecation.
+		Recorder: mgr.GetEventRecorderFor("imagepullsecret-patcher"), //nolint:staticcheck // old events API is intentional
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServiceAccount")
 		os.Exit(1)
@@ -223,6 +227,7 @@ func main() {
 		APIReader: mgr.GetAPIReader(),
 		Scheme:    mgr.GetScheme(),
 		Config:    controllerConfig,
+		Recorder:  mgr.GetEventRecorderFor("imagepullsecret-patcher"), //nolint:staticcheck // old events API is intentional
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Secret")
 		os.Exit(1)

--- a/deploy/helm/_generated/rbac/role.yaml
+++ b/deploy/helm/_generated/rbac/role.yaml
@@ -6,6 +6,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/tamcore/imagepullsecret-patcher/internal/utils"
+)
+
+// emitEvent records an Event, tolerating a nil recorder (unit tests may omit
+// one) and a nil object.
+func emitEvent(rec record.EventRecorder, obj runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	if rec == nil || obj == nil {
+		return
+	}
+	rec.Eventf(obj, eventType, reason, messageFmt, args...)
+}
+
+// recordSecretAction emits the Event describing what ReconcileImagePullSecret
+// did to the managed secret. It is shared by both reconcilers because either
+// can be the one that creates or updates the secret. SecretUnchanged emits
+// nothing, so periodic resync stays quiet.
+func recordSecretAction(rec record.EventRecorder, secretName string, sec *corev1.Secret, action utils.SecretAction) {
+	switch action {
+	case utils.SecretCreated:
+		emitEvent(rec, sec, corev1.EventTypeNormal, "Created", "Created managed imagePullSecret %q", secretName)
+	case utils.SecretUpdated:
+		emitEvent(rec, sec, corev1.EventTypeNormal, "Updated", "Updated managed imagePullSecret %q", secretName)
+	case utils.SecretAdopted:
+		emitEvent(rec, sec, corev1.EventTypeNormal, "Adopted", "Adopted pre-existing imagePullSecret %q", secretName)
+	case utils.SecretRecreated:
+		emitEvent(rec, sec, corev1.EventTypeWarning, "Recreated",
+			"Recreated imagePullSecret %q: pre-existing secret had an incompatible type", secretName)
+	}
+}

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -44,6 +45,8 @@ type SecretReconciler struct {
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
 	Config    *config.Config
+	// Recorder emits Events on reconciled objects. May be nil in tests.
+	Recorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
@@ -76,20 +79,49 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	log.Info("Reconciling imagePullSecret", "namespace", req.Namespace)
-	doPatch := false
-	if didPatch, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, req.Namespace); err != nil {
+	sec, action, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, req.Namespace)
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile imagePullSecret in namespace %q: %w", req.Namespace, err)
-	} else {
-		doPatch = didPatch
 	}
+	r.recordSecretAction(sec, action)
 
-	if doPatch && r.Config.FeatureDeletePods {
-		if err := utils.CleanupPodsForNamespace(ctx, r.Config, r.Client, req.Namespace); err != nil {
+	if action != utils.SecretUnchanged && r.Config.FeatureDeletePods {
+		deleted, err := utils.CleanupPodsForNamespace(ctx, r.Config, r.Client, req.Namespace)
+		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to cleanup Pods in unauthorized state: %w", err)
+		}
+		if deleted > 0 {
+			r.emitf(sec, corev1.EventTypeNormal, "PodsCleanedUp",
+				"Deleted %d Pod(s) stuck in an image pull failure", deleted)
 		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// recordSecretAction emits the Event describing what ReconcileImagePullSecret
+// did to the managed secret. SecretUnchanged emits nothing (so periodic resync
+// stays quiet).
+func (r *SecretReconciler) recordSecretAction(sec *corev1.Secret, action utils.SecretAction) {
+	switch action {
+	case utils.SecretCreated:
+		r.emitf(sec, corev1.EventTypeNormal, "Created", "Created managed imagePullSecret %q", r.Config.SecretName)
+	case utils.SecretUpdated:
+		r.emitf(sec, corev1.EventTypeNormal, "Updated", "Updated managed imagePullSecret %q", r.Config.SecretName)
+	case utils.SecretAdopted:
+		r.emitf(sec, corev1.EventTypeNormal, "Adopted", "Adopted pre-existing imagePullSecret %q", r.Config.SecretName)
+	case utils.SecretRecreated:
+		r.emitf(sec, corev1.EventTypeWarning, "Recreated",
+			"Recreated imagePullSecret %q: pre-existing secret had an incompatible type", r.Config.SecretName)
+	}
+}
+
+// emitf records an Event, tolerating a nil Recorder (unit tests may omit it).
+func (r *SecretReconciler) emitf(obj runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	if r.Recorder == nil || obj == nil {
+		return
+	}
+	r.Recorder.Eventf(obj, eventType, reason, messageFmt, args...)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -83,7 +83,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile imagePullSecret in namespace %q: %w", req.Namespace, err)
 	}
-	r.recordSecretAction(sec, action)
+	recordSecretAction(r.Recorder, r.Config.SecretName, sec, action)
 
 	if action != utils.SecretUnchanged && r.Config.FeatureDeletePods {
 		deleted, err := utils.CleanupPodsForNamespace(ctx, r.Config, r.Client, req.Namespace)
@@ -91,37 +91,12 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, fmt.Errorf("failed to cleanup Pods in unauthorized state: %w", err)
 		}
 		if deleted > 0 {
-			r.emitf(sec, corev1.EventTypeNormal, "PodsCleanedUp",
+			emitEvent(r.Recorder, sec, corev1.EventTypeNormal, "PodsCleanedUp",
 				"Deleted %d Pod(s) stuck in an image pull failure", deleted)
 		}
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// recordSecretAction emits the Event describing what ReconcileImagePullSecret
-// did to the managed secret. SecretUnchanged emits nothing (so periodic resync
-// stays quiet).
-func (r *SecretReconciler) recordSecretAction(sec *corev1.Secret, action utils.SecretAction) {
-	switch action {
-	case utils.SecretCreated:
-		r.emitf(sec, corev1.EventTypeNormal, "Created", "Created managed imagePullSecret %q", r.Config.SecretName)
-	case utils.SecretUpdated:
-		r.emitf(sec, corev1.EventTypeNormal, "Updated", "Updated managed imagePullSecret %q", r.Config.SecretName)
-	case utils.SecretAdopted:
-		r.emitf(sec, corev1.EventTypeNormal, "Adopted", "Adopted pre-existing imagePullSecret %q", r.Config.SecretName)
-	case utils.SecretRecreated:
-		r.emitf(sec, corev1.EventTypeWarning, "Recreated",
-			"Recreated imagePullSecret %q: pre-existing secret had an incompatible type", r.Config.SecretName)
-	}
-}
-
-// emitf records an Event, tolerating a nil Recorder (unit tests may omit it).
-func (r *SecretReconciler) emitf(obj runtime.Object, eventType, reason, messageFmt string, args ...any) {
-	if r.Recorder == nil || obj == nil {
-		return
-	}
-	r.Recorder.Eventf(obj, eventType, reason, messageFmt, args...)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/secret_controller_test.go
+++ b/internal/controller/secret_controller_test.go
@@ -29,6 +29,7 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -148,6 +149,94 @@ var _ = Describe("Secret Controller", func() {
 			Expect(after.ResourceVersion).To(Equal(before.ResourceVersion))
 			Expect(after.Data).To(Equal(map[string][]byte{"foo": []byte("bar")}))
 			Expect(after.Type).To(Equal(corev1.SecretTypeOpaque))
+		})
+	})
+
+	Context("When emitting Events on reconcile", func() {
+		// drainEvents collects every buffered Event string from a FakeRecorder
+		// without blocking. FakeRecorder formats each as "<Type> <Reason> <message>".
+		drainEvents := func(rec *record.FakeRecorder) []string {
+			var events []string
+			for {
+				select {
+				case e := <-rec.Events:
+					events = append(events, e)
+				default:
+					return events
+				}
+			}
+		}
+
+		It("should emit a Created Event when the managed secret is created", func() {
+			scheme := newTestScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: secretNsManaged}},
+			).Build()
+			rec := record.NewFakeRecorder(10)
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg, Recorder: rec}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsManaged},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drainEvents(rec)).To(ContainElement(And(
+				ContainSubstring("Normal"),
+				ContainSubstring("Created"),
+			)))
+		})
+
+		It("should emit an Updated Event when stale secret data is corrected", func() {
+			scheme := newTestScheme()
+			staleSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cfg.SecretName,
+					Namespace: secretNsManaged,
+					Labels:    map[string]string{config.LabelManagedBy: config.AnnotationAppName},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(`{"auths":{"stale":{}}}`)},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: secretNsManaged}},
+				staleSecret,
+			).Build()
+			rec := record.NewFakeRecorder(10)
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg, Recorder: rec}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsManaged},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drainEvents(rec)).To(ContainElement(ContainSubstring("Updated")))
+		})
+
+		It("should emit no Event when the managed secret is already up-to-date", func() {
+			scheme := newTestScheme()
+			upToDate := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        cfg.SecretName,
+					Namespace:   secretNsManaged,
+					Labels:      map[string]string{config.LabelManagedBy: config.AnnotationAppName},
+					Annotations: map[string]string{config.AnnotationManagedBy: config.AnnotationAppName},
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte(imagePullSecretData)},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: secretNsManaged}},
+				upToDate,
+			).Build()
+			rec := record.NewFakeRecorder(10)
+			reconciler := &SecretReconciler{Client: c, Scheme: scheme, Config: cfg, Recorder: rec}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cfg.SecretName, Namespace: secretNsManaged},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drainEvents(rec)).To(BeEmpty())
 		})
 	})
 

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -98,10 +98,15 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	// Ensure imagePullSecret exists before we attach it to the ServiceAccount
-	if _, _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, serviceAccount.GetNamespace()); err != nil {
+	// Ensure imagePullSecret exists before we attach it to the ServiceAccount.
+	// The SA controller can be the one that first creates the secret, so it
+	// records the secret Event too (the SecretReconciler would otherwise see an
+	// already-current secret and stay silent).
+	sec, action, err := utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, serviceAccount.GetNamespace())
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile imagePullSecret in namespace %q: %w", serviceAccount.GetNamespace(), err)
 	}
+	recordSecretAction(r.Recorder, r.Config.SecretName, sec, action)
 
 	patchFrom := client.MergeFrom(serviceAccount.DeepCopy())
 	patchedServiceAccount := r.getPatchedServiceAccount(serviceAccount.DeepCopy(), r.Config.SecretName)
@@ -113,7 +118,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				serviceAccount.GetName(), serviceAccount.GetNamespace(), err)
 		}
 		log.Info("Attached ImagePullSecret to ServiceAccount", "serviceaccount", serviceAccount.GetName(), "namespace", serviceAccount.GetNamespace())
-		r.emitf(serviceAccount, corev1.EventTypeNormal, "ImagePullSecretAttached",
+		emitEvent(r.Recorder, serviceAccount, corev1.EventTypeNormal, "ImagePullSecretAttached",
 			"Attached imagePullSecret %q to ServiceAccount", r.Config.SecretName)
 
 		if r.Config.FeatureDeletePods {
@@ -124,21 +129,13 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 			log.Info("Cleaned up Pods belonging to ServiceAccount", "serviceaccount", serviceAccount.GetName(), "namespace", serviceAccount.GetNamespace())
 			if deleted > 0 {
-				r.emitf(serviceAccount, corev1.EventTypeNormal, "PodsCleanedUp",
+				emitEvent(r.Recorder, serviceAccount, corev1.EventTypeNormal, "PodsCleanedUp",
 					"Deleted %d Pod(s) stuck in an image pull failure", deleted)
 			}
 		}
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// emitf records an Event, tolerating a nil Recorder (unit tests may omit it).
-func (r *ServiceAccountReconciler) emitf(obj runtime.Object, eventType, reason, messageFmt string, args ...any) {
-	if r.Recorder == nil || obj == nil {
-		return
-	}
-	r.Recorder.Eventf(obj, eventType, reason, messageFmt, args...)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/serviceaccount_controller.go
+++ b/internal/controller/serviceaccount_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,11 +59,14 @@ type ServiceAccountReconciler struct {
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
 	Config    *config.Config
+	// Recorder emits Events on reconciled objects. May be nil in tests.
+	Recorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
@@ -95,7 +99,7 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Ensure imagePullSecret exists before we attach it to the ServiceAccount
-	if _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, serviceAccount.GetNamespace()); err != nil {
+	if _, _, err = utils.ReconcileImagePullSecret(ctx, r.Client, r.APIReader, r.Config, serviceAccount.GetNamespace()); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile imagePullSecret in namespace %q: %w", serviceAccount.GetNamespace(), err)
 	}
 
@@ -109,17 +113,32 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				serviceAccount.GetName(), serviceAccount.GetNamespace(), err)
 		}
 		log.Info("Attached ImagePullSecret to ServiceAccount", "serviceaccount", serviceAccount.GetName(), "namespace", serviceAccount.GetNamespace())
+		r.emitf(serviceAccount, corev1.EventTypeNormal, "ImagePullSecretAttached",
+			"Attached imagePullSecret %q to ServiceAccount", r.Config.SecretName)
 
 		if r.Config.FeatureDeletePods {
 			// Run Pod cleanup only if we're freshly attaching the imagePullSecret to the ServiceAccount
-			if err = utils.CleanupPodsForSA(ctx, r.Client, serviceAccount.GetNamespace(), serviceAccount.GetName()); err != nil {
+			deleted, err := utils.CleanupPodsForSA(ctx, r.Client, serviceAccount.GetNamespace(), serviceAccount.GetName())
+			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to cleanup Pods in unauthorized state: %w", err)
 			}
 			log.Info("Cleaned up Pods belonging to ServiceAccount", "serviceaccount", serviceAccount.GetName(), "namespace", serviceAccount.GetNamespace())
+			if deleted > 0 {
+				r.emitf(serviceAccount, corev1.EventTypeNormal, "PodsCleanedUp",
+					"Deleted %d Pod(s) stuck in an image pull failure", deleted)
+			}
 		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// emitf records an Event, tolerating a nil Recorder (unit tests may omit it).
+func (r *ServiceAccountReconciler) emitf(obj runtime.Object, eventType, reason, messageFmt string, args ...any) {
+	if r.Recorder == nil || obj == nil {
+		return
+	}
+	r.Recorder.Eventf(obj, eventType, reason, messageFmt, args...)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/serviceaccount_controller_test.go
+++ b/internal/controller/serviceaccount_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -210,6 +211,50 @@ var _ = Describe("ServiceAccount Controller", func() {
 				Namespace: unmanagedPod.GetNamespace(),
 			}, foundUnmanagedPod)
 			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		It("should emit ImagePullSecretAttached and PodsCleanedUp Events", func() {
+			namespace, serviceAccount, serviceAccountNN, _ := makeObjects("testns-events", saDefault, cfg.SecretName)
+
+			By("Creating the Namespace and ServiceAccount")
+			Expect(k8sClient.Create(ctx, namespace.DeepCopy())).Should(Succeed())
+			Expect(k8sClient.Create(ctx, serviceAccount.DeepCopy())).Should(Succeed())
+
+			By("Creating a managed Pod stuck in ImagePullBackOff")
+			managedPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "events-backoff", Namespace: serviceAccount.GetNamespace()},
+				Spec:       corev1.PodSpec{ServiceAccountName: serviceAccount.GetName()},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, managedPod)).Should(Succeed())
+
+			By("Reconciling with a recorder attached")
+			rec := record.NewFakeRecorder(10)
+			serviceAccountReconciler := &ServiceAccountReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Config:   cfg,
+				Recorder: rec,
+			}
+			_, err = serviceAccountReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: serviceAccountNN})
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Collecting emitted Events")
+			var events []string
+			for draining := true; draining; {
+				select {
+				case e := <-rec.Events:
+					events = append(events, e)
+				default:
+					draining = false
+				}
+			}
+			Expect(events).To(ContainElement(ContainSubstring("ImagePullSecretAttached")))
+			Expect(events).To(ContainElement(ContainSubstring("PodsCleanedUp")))
 		})
 
 		It("should ignore a ServiceAccount that no longer exists", func() {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -127,23 +127,27 @@ func FetchServiceAccount(ctx context.Context, client client.Client, namespace st
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
 
-func CleanupPodsForNamespace(ctx context.Context, c *config.Config, k8sClient client.Client, namespace string) error {
+// CleanupPodsForNamespace deletes pods stuck in an image pull failure whose
+// ServiceAccount is managed by this controller. It returns the number of pods
+// deleted so callers can decide whether to emit an Event.
+func CleanupPodsForNamespace(ctx context.Context, c *config.Config, k8sClient client.Client, namespace string) (int, error) {
 	ns, err := FetchNamespace(ctx, k8sClient, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to fetch namespace: %w", err)
+		return 0, fmt.Errorf("failed to fetch namespace: %w", err)
 	}
 	if IsNamespaceExcluded(c, ns) {
-		return nil
+		return 0, nil
 	}
 
 	podList := &corev1.PodList{}
 	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace)); err != nil {
-		return fmt.Errorf("failed to fetch pods: %w", err)
+		return 0, fmt.Errorf("failed to fetch pods: %w", err)
 	}
 
 	// Cache the managed-state per ServiceAccount so pods sharing one don't
 	// trigger repeated lookups.
 	saManaged := map[string]bool{}
+	deleted := 0
 	for _, pod := range podList.Items {
 		managed, known := saManaged[pod.Spec.ServiceAccountName]
 		if !known {
@@ -154,7 +158,7 @@ func CleanupPodsForNamespace(ctx context.Context, c *config.Config, k8sClient cl
 					saManaged[pod.Spec.ServiceAccountName] = false
 					continue
 				}
-				return fmt.Errorf("failed to fetch serviceAccount: %w", err)
+				return deleted, fmt.Errorf("failed to fetch serviceAccount: %w", err)
 			}
 			managed = IsServiceAccountManaged(c, ns, sa)
 			saManaged[pod.Spec.ServiceAccountName] = managed
@@ -163,36 +167,48 @@ func CleanupPodsForNamespace(ctx context.Context, c *config.Config, k8sClient cl
 			continue
 		}
 
-		if err := deletePodIfImagePullFailed(ctx, k8sClient, &pod); err != nil {
-			return err
+		didDelete, err := deletePodIfImagePullFailed(ctx, k8sClient, &pod)
+		if err != nil {
+			return deleted, err
+		}
+		if didDelete {
+			deleted++
 		}
 	}
 
-	return nil
+	return deleted, nil
 }
 
-func CleanupPodsForSA(ctx context.Context, k8sClient client.Client, namespace string, serviceAccount string) error {
+// CleanupPodsForSA deletes pods of the given ServiceAccount stuck in an image
+// pull failure. It returns the number of pods deleted.
+func CleanupPodsForSA(ctx context.Context, k8sClient client.Client, namespace string, serviceAccount string) (int, error) {
 	podList := &corev1.PodList{}
 	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace)); err != nil {
-		return fmt.Errorf("failed to fetch pods: %w", err)
+		return 0, fmt.Errorf("failed to fetch pods: %w", err)
 	}
 
+	deleted := 0
 	for _, pod := range podList.Items {
 		if pod.Spec.ServiceAccountName != serviceAccount {
 			continue
 		}
 
-		if err := deletePodIfImagePullFailed(ctx, k8sClient, &pod); err != nil {
-			return err
+		didDelete, err := deletePodIfImagePullFailed(ctx, k8sClient, &pod)
+		if err != nil {
+			return deleted, err
+		}
+		if didDelete {
+			deleted++
 		}
 	}
 
-	return nil
+	return deleted, nil
 }
 
 // deletePodIfImagePullFailed deletes the pod once if any of its containers is
-// stuck in an image pull failure. An already-deleted pod is not an error.
-func deletePodIfImagePullFailed(ctx context.Context, k8sClient client.Client, pod *corev1.Pod) error {
+// stuck in an image pull failure. It reports whether the pod was deleted. An
+// already-deleted pod is not an error and still counts as deleted.
+func deletePodIfImagePullFailed(ctx context.Context, k8sClient client.Client, pod *corev1.Pod) (bool, error) {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.State.Waiting == nil {
 			continue
@@ -205,23 +221,39 @@ func deletePodIfImagePullFailed(ctx context.Context, k8sClient client.Client, po
 		log.FromContext(ctx).Info("Deleting Pod due to image pull failure",
 			"pod", pod.Name, "namespace", pod.Namespace, "reason", reason)
 		if err := k8sClient.Delete(ctx, pod); err != nil && !apierrs.IsNotFound(err) {
-			return fmt.Errorf("failed to delete Pod %q in namespace %q: %w", pod.Name, pod.Namespace, err)
+			return false, fmt.Errorf("failed to delete Pod %q in namespace %q: %w", pod.Name, pod.Namespace, err)
 		}
 		// The pod is deleted; checking the remaining containers would only
 		// trigger redundant deletes.
-		return nil
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
-func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiReader client.Reader, c *config.Config, namespace string) (bool, error) {
+// SecretAction reports what ReconcileImagePullSecret did to the managed secret,
+// so callers can emit an Event describing the exact transition.
+type SecretAction int
+
+const (
+	SecretUnchanged SecretAction = iota // no change was necessary
+	SecretCreated                       // the secret did not exist and was created
+	SecretUpdated                       // an existing managed secret was patched (data/labels/annotations)
+	SecretRecreated                     // a pre-existing secret with incompatible type was deleted and recreated
+	SecretAdopted                       // a pre-existing compatible secret was patched into managed state
+)
+
+// ReconcileImagePullSecret ensures the managed imagePullSecret exists and is
+// up-to-date in the given namespace. It returns the reconciled Secret (so the
+// caller has an object to attach an Event to) and a SecretAction describing what
+// happened.
+func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiReader client.Reader, c *config.Config, namespace string) (*corev1.Secret, SecretAction, error) {
 	if apiReader == nil {
 		apiReader = k8sClient
 	}
 
 	desiredSecret, err := ConstructImagePullSecret(c, namespace)
 	if err != nil {
-		return false, fmt.Errorf("failed to construct imagePullSecret: %w", err)
+		return nil, SecretUnchanged, fmt.Errorf("failed to construct imagePullSecret: %w", err)
 	}
 
 	secret := &corev1.Secret{}
@@ -240,11 +272,11 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiR
 					// installation without the managed-by label). Adopt it.
 					return adoptExistingSecret(ctx, k8sClient, apiReader, desiredSecret)
 				}
-				return false, fmt.Errorf("failed to create Secret: %w", err)
+				return nil, SecretUnchanged, fmt.Errorf("failed to create Secret: %w", err)
 			}
-			return true, nil
+			return desiredSecret, SecretCreated, nil
 		}
-		return false, fmt.Errorf("failed to fetch Secret: %w", err)
+		return nil, SecretUnchanged, fmt.Errorf("failed to fetch Secret: %w", err)
 	}
 
 	patchFrom := client.MergeFrom(secret.DeepCopy())
@@ -266,10 +298,11 @@ func ReconcileImagePullSecret(ctx context.Context, k8sClient client.Client, apiR
 
 	if doPatch {
 		if err = k8sClient.Patch(ctx, secret, patchFrom); err != nil {
-			return false, fmt.Errorf("failed to patch Secret %q in namespace %q: %w", desiredSecret.GetName(), desiredSecret.GetNamespace(), err)
+			return nil, SecretUnchanged, fmt.Errorf("failed to patch Secret %q in namespace %q: %w", desiredSecret.GetName(), desiredSecret.GetNamespace(), err)
 		}
+		return secret, SecretUpdated, nil
 	}
-	return doPatch, nil
+	return secret, SecretUnchanged, nil
 }
 
 // enforceMapEntries returns a copy of current with every key/value pair from
@@ -296,10 +329,10 @@ func enforceMapEntries(current map[string]string, desired map[string]string) (ma
 // the uncached apiReader. Secrets of the correct type are adopted in place via
 // merge patch. Secret.type is immutable in Kubernetes, so a secret of any
 // other type can never serve as imagePullSecret and is deleted and recreated.
-func adoptExistingSecret(ctx context.Context, k8sClient client.Client, apiReader client.Reader, desiredSecret *corev1.Secret) (bool, error) {
+func adoptExistingSecret(ctx context.Context, k8sClient client.Client, apiReader client.Reader, desiredSecret *corev1.Secret) (*corev1.Secret, SecretAction, error) {
 	live := &corev1.Secret{}
 	if err := apiReader.Get(ctx, client.ObjectKeyFromObject(desiredSecret), live); err != nil {
-		return false, fmt.Errorf("failed to fetch pre-existing Secret: %v", err)
+		return nil, SecretUnchanged, fmt.Errorf("failed to fetch pre-existing Secret: %v", err)
 	}
 
 	if live.Type == corev1.SecretTypeDockerConfigJson {
@@ -312,17 +345,18 @@ func adoptExistingSecret(ctx context.Context, k8sClient client.Client, apiReader
 		"type", string(live.Type),
 	)
 	if err := k8sClient.Delete(ctx, live, client.Preconditions{UID: &live.UID}); err != nil {
-		return false, fmt.Errorf("failed to delete pre-existing Secret with incompatible type: %v", err)
+		return nil, SecretUnchanged, fmt.Errorf("failed to delete pre-existing Secret with incompatible type: %v", err)
 	}
-	if err := k8sClient.Create(ctx, desiredSecret.DeepCopy()); err != nil {
-		return false, fmt.Errorf("failed to recreate Secret: %v", err)
+	recreated := desiredSecret.DeepCopy()
+	if err := k8sClient.Create(ctx, recreated); err != nil {
+		return nil, SecretUnchanged, fmt.Errorf("failed to recreate Secret: %v", err)
 	}
-	return true, nil
+	return recreated, SecretRecreated, nil
 }
 
 // patchUnmanagedSecret patches an existing secret that is not in the label-filtered cache.
 // This handles upgrades from older versions that created secrets without the managed-by label.
-func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredSecret *corev1.Secret) (bool, error) {
+func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredSecret *corev1.Secret) (*corev1.Secret, SecretAction, error) {
 	patchBytes, err := json.Marshal(map[string]any{
 		"metadata": map[string]any{
 			"labels":      desiredSecret.Labels,
@@ -331,7 +365,7 @@ func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredS
 		"data": desiredSecret.Data,
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed to marshal patch: %w", err)
+		return nil, SecretUnchanged, fmt.Errorf("failed to marshal patch: %w", err)
 	}
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -340,9 +374,9 @@ func patchUnmanagedSecret(ctx context.Context, k8sClient client.Client, desiredS
 		},
 	}
 	if err := k8sClient.Patch(ctx, target, client.RawPatch(types.MergePatchType, patchBytes)); err != nil {
-		return false, fmt.Errorf("failed to patch existing Secret: %w", err)
+		return nil, SecretUnchanged, fmt.Errorf("failed to patch existing Secret: %w", err)
 	}
-	return true, nil
+	return target, SecretAdopted, nil
 }
 
 func ConstructImagePullSecret(c *config.Config, namespace string) (*corev1.Secret, error) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -398,7 +398,7 @@ func Test_CleanupPodsForNamespace(t *testing.T) {
 			c := newCountingClient(&deletes, &saGets, tt.deleteNotFound, tt.objects...)
 
 			// Act
-			err := CleanupPodsForNamespace(context.Background(), cfg, c, nsDefault)
+			deleted, err := CleanupPodsForNamespace(context.Background(), cfg, c, nsDefault)
 
 			// Assert
 			if (err != nil) != tt.wantErr {
@@ -406,6 +406,9 @@ func Test_CleanupPodsForNamespace(t *testing.T) {
 			}
 			if deletes != tt.wantDeletes {
 				t.Errorf("CleanupPodsForNamespace() deletes = %d, want %d", deletes, tt.wantDeletes)
+			}
+			if !tt.wantErr && deleted != tt.wantDeletes {
+				t.Errorf("CleanupPodsForNamespace() returned count = %d, want %d", deleted, tt.wantDeletes)
 			}
 			if saGets > tt.maxSAGets {
 				t.Errorf("CleanupPodsForNamespace() serviceaccount gets = %d, want at most %d", saGets, tt.maxSAGets)
@@ -428,7 +431,7 @@ func Test_CleanupPodsForNamespace(t *testing.T) {
 		)
 
 		// Act
-		err := CleanupPodsForNamespace(context.Background(), cfg, c, "kube-excluded")
+		deleted, err := CleanupPodsForNamespace(context.Background(), cfg, c, "kube-excluded")
 
 		// Assert
 		if err != nil {
@@ -436,6 +439,9 @@ func Test_CleanupPodsForNamespace(t *testing.T) {
 		}
 		if deletes != 0 {
 			t.Errorf("CleanupPodsForNamespace() deletes = %d, want 0", deletes)
+		}
+		if deleted != 0 {
+			t.Errorf("CleanupPodsForNamespace() returned count = %d, want 0", deleted)
 		}
 	})
 }
@@ -470,7 +476,7 @@ func Test_CleanupPodsForSA(t *testing.T) {
 			c := newCountingClient(&deletes, &saGets, tt.deleteNotFound, tt.objects...)
 
 			// Act
-			err := CleanupPodsForSA(context.Background(), c, nsDefault, nsDefault)
+			deleted, err := CleanupPodsForSA(context.Background(), c, nsDefault, nsDefault)
 
 			// Assert
 			if err != nil {
@@ -478,6 +484,9 @@ func Test_CleanupPodsForSA(t *testing.T) {
 			}
 			if deletes != tt.wantDeletes {
 				t.Errorf("CleanupPodsForSA() deletes = %d, want %d", deletes, tt.wantDeletes)
+			}
+			if deleted != tt.wantDeletes {
+				t.Errorf("CleanupPodsForSA() returned count = %d, want %d", deleted, tt.wantDeletes)
 			}
 		})
 	}
@@ -616,15 +625,15 @@ func desiredSecretFixture(t *testing.T, cfg *config.Config, mutate func(*corev1.
 
 func Test_ReconcileImagePullSecret(t *testing.T) {
 	tests := []struct {
-		name        string
-		existing    func(t *testing.T, cfg *config.Config) *corev1.Secret
-		wantChanged bool
-		assert      func(t *testing.T, cfg *config.Config, got *corev1.Secret)
+		name       string
+		existing   func(t *testing.T, cfg *config.Config) *corev1.Secret
+		wantAction SecretAction
+		assert     func(t *testing.T, cfg *config.Config, got *corev1.Secret)
 	}{
 		{
-			name:        "creates the managed secret when absent",
-			existing:    nil,
-			wantChanged: true,
+			name:       "creates the managed secret when absent",
+			existing:   nil,
+			wantAction: SecretCreated,
 			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
 				if got.Name != cfg.SecretName {
 					t.Errorf("secret name = %q, want %q", got.Name, cfg.SecretName)
@@ -653,7 +662,7 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 					}
 				})
 			},
-			wantChanged: true,
+			wantAction: SecretUpdated,
 			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
 				if data := string(got.Data[corev1.DockerConfigJsonKey]); data != reconcileDockerCfgJSON {
 					t.Errorf("secret data = %q, want %q", data, reconcileDockerCfgJSON)
@@ -661,12 +670,12 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 			},
 		},
 		{
-			name: "returns false when the managed secret is up-to-date",
+			name: "returns unchanged when the managed secret is up-to-date",
 			existing: func(t *testing.T, cfg *config.Config) *corev1.Secret {
 				return desiredSecretFixture(t, cfg, nil)
 			},
-			wantChanged: false,
-			assert:      nil,
+			wantAction: SecretUnchanged,
+			assert:     nil,
 		},
 		{
 			name: "preserves foreign annotations and skips patch when up-to-date",
@@ -675,7 +684,7 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 					s.Annotations[foreignAnnotationKey] = foreignAnnotationValue
 				})
 			},
-			wantChanged: false,
+			wantAction: SecretUnchanged,
 			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
 				if got.Annotations[foreignAnnotationKey] != foreignAnnotationValue {
 					t.Errorf("foreign annotation = %q, want %q",
@@ -692,7 +701,7 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 					}
 				})
 			},
-			wantChanged: true,
+			wantAction: SecretUpdated,
 			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
 				if got.Annotations[config.AnnotationManagedBy] != config.AnnotationAppName {
 					t.Errorf("managed-by annotation = %q, want %q",
@@ -711,7 +720,7 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 					s.Labels = nil
 				})
 			},
-			wantChanged: true,
+			wantAction: SecretUpdated,
 			assert: func(t *testing.T, cfg *config.Config, got *corev1.Secret) {
 				if got.Labels[config.LabelManagedBy] != config.AnnotationAppName {
 					t.Errorf("managed-by label = %q, want %q",
@@ -731,14 +740,19 @@ func Test_ReconcileImagePullSecret(t *testing.T) {
 			k8sClient := newFakeClient(t, objs...)
 
 			// Act (nil apiReader exercises the fallback to k8sClient)
-			changed, err := ReconcileImagePullSecret(context.Background(), k8sClient, nil, cfg, nsDefault)
+			sec, action, err := ReconcileImagePullSecret(context.Background(), k8sClient, nil, cfg, nsDefault)
 
 			// Assert
 			if err != nil {
 				t.Fatalf("ReconcileImagePullSecret() error = %v", err)
 			}
-			if changed != tt.wantChanged {
-				t.Errorf("ReconcileImagePullSecret() changed = %v, want %v", changed, tt.wantChanged)
+			if action != tt.wantAction {
+				t.Errorf("ReconcileImagePullSecret() action = %v, want %v", action, tt.wantAction)
+			}
+			// On any real transition the reconciled Secret is returned so the
+			// caller has an object to attach an Event to.
+			if tt.wantAction != SecretUnchanged && sec == nil {
+				t.Error("ReconcileImagePullSecret() returned nil Secret on a changing action")
 			}
 			got := &corev1.Secret{}
 			if err := k8sClient.Get(context.Background(),
@@ -762,16 +776,19 @@ func Test_ReconcileImagePullSecret_AdoptsPreExistingSecrets(t *testing.T) {
 		name         string
 		existingType corev1.SecretType
 		wantDeletes  int
+		wantAction   SecretAction
 	}{
 		{
 			name:         "adopts a compatible pre-existing secret via patch without deleting it",
 			existingType: corev1.SecretTypeDockerConfigJson,
 			wantDeletes:  0,
+			wantAction:   SecretAdopted,
 		},
 		{
 			name:         "deletes and recreates a pre-existing secret with incompatible type",
 			existingType: corev1.SecretTypeOpaque,
 			wantDeletes:  1,
+			wantAction:   SecretRecreated,
 		},
 	}
 	for _, tt := range tests {
@@ -818,14 +835,17 @@ func Test_ReconcileImagePullSecret_AdoptsPreExistingSecrets(t *testing.T) {
 			})
 
 			// Act
-			changed, err := ReconcileImagePullSecret(context.Background(), labelFilteredClient, rawClient, cfg, nsDefault)
+			sec, action, err := ReconcileImagePullSecret(context.Background(), labelFilteredClient, rawClient, cfg, nsDefault)
 
 			// Assert
 			if err != nil {
 				t.Fatalf("ReconcileImagePullSecret() error = %v", err)
 			}
-			if !changed {
-				t.Errorf("ReconcileImagePullSecret() changed = false, want true")
+			if action != tt.wantAction {
+				t.Errorf("ReconcileImagePullSecret() action = %v, want %v", action, tt.wantAction)
+			}
+			if sec == nil {
+				t.Error("ReconcileImagePullSecret() returned nil Secret, want a reconciled object")
 			}
 			if deleteCalls != tt.wantDeletes {
 				t.Errorf("delete calls = %d, want %d", deleteCalls, tt.wantDeletes)
@@ -955,7 +975,7 @@ func Test_ReconcileImagePullSecret_WrapsGetError(t *testing.T) {
 	}
 
 	// Act
-	_, err := ReconcileImagePullSecret(context.Background(), k8sClient, nil, cfg, nsDefault)
+	_, _, err := ReconcileImagePullSecret(context.Background(), k8sClient, nil, cfg, nsDefault)
 
 	// Assert
 	if err == nil {

--- a/tests/e2e/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
                 namespace: managed-namespace
                 labels:
                   app.kubernetes.io/managed-by: imagepullsecret-patcher
-        
+
         - assert:
             resource:
               apiVersion: v1
@@ -32,6 +32,33 @@ spec:
                 namespace: managed-namespace
               imagePullSecrets:
               - name: global-imagepullsecret
+
+    - name: "Check reconcile Events are emitted (managed-namespace)"
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Event
+              type: Normal
+              reason: ImagePullSecretAttached
+              source:
+                component: imagepullsecret-patcher
+              involvedObject:
+                kind: ServiceAccount
+                name: default
+                namespace: managed-namespace
+
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Event
+              reason: Created
+              source:
+                component: imagepullsecret-patcher
+              involvedObject:
+                kind: Secret
+                name: global-imagepullsecret
+                namespace: managed-namespace
 
     - name: "Check if imagePullSecrets are absent and not attached to the ServiceAccount (unmanaged-namespace)"
       try:
@@ -63,7 +90,7 @@ spec:
     #     #       metadata:
     #     #         name: global-imagepullsecret
     #     #         namespace: kube-unmanaged
-        
+
     #     - assert:
     #         resource:
     #           apiVersion: v1
@@ -75,4 +102,3 @@ spec:
     #         expect:
     #         - check:
     #             ($error != null): true
-    

--- a/tests/e2e/chainsaw-test.yaml
+++ b/tests/e2e/chainsaw-test.yaml
@@ -39,6 +39,11 @@ spec:
             resource:
               apiVersion: v1
               kind: Event
+              # Events live in the namespace of their involvedObject; scope the
+              # lookup there so chainsaw doesn't match Events in its own
+              # ephemeral test namespace.
+              metadata:
+                namespace: managed-namespace
               type: Normal
               reason: ImagePullSecretAttached
               source:
@@ -52,6 +57,8 @@ spec:
             resource:
               apiVersion: v1
               kind: Event
+              metadata:
+                namespace: managed-namespace
               reason: Created
               source:
                 component: imagepullsecret-patcher


### PR DESCRIPTION
## Context

Like a proper controller, `imagepullsecret-patcher` should record Kubernetes **Events** on the objects it reconciles — today it only writes structured logs. Events let operators see *why* a ServiceAccount grew an imagePullSecret or a Secret changed via `kubectl describe`, without grepping controller logs.

## What changed

**Event catalog** (emitted only on real state transitions — periodic resync stays quiet):

| Reason | Type | Involved object | When |
|---|---|---|---|
| `Created` | Normal | Secret | managed imagePullSecret created |
| `Updated` | Normal | Secret | data/labels/annotations drift corrected |
| `Recreated` | Warning | Secret | pre-existing secret had incompatible type → delete+recreate |
| `Adopted` | Normal | Secret | pre-existing compatible secret patched into managed state |
| `ImagePullSecretAttached` | Normal | ServiceAccount | secret appended to SA `imagePullSecrets` |
| `PodsCleanedUp` | Normal | ServiceAccount / Secret | `--deletepods`: only when >0 pods deleted |

- **`internal/utils`** stays free of any `record` dependency: `ReconcileImagePullSecret` now returns the reconciled `*Secret` + a typed `SecretAction`; `CleanupPods*` return the number of pods deleted.
- **Reconcilers** hold a shared `record.EventRecorder` (source `imagepullsecret-patcher`) and emit inside the existing change branches.
- **RBAC**: added `//+kubebuilder:rbac ... events` marker; regenerated the Helm ClusterRole (`events: [create, patch]`).
- Failure events are intentionally **out of scope** — transient reconcile errors are already logged, requeued with backoff, and counted in metrics; per-error events would be spam.

## Test plan

- [x] `make test` — unit/integration incl. new `record.FakeRecorder` assertions (Created/Updated/Unchanged, ImagePullSecretAttached, PodsCleanedUp). utils coverage 83.4%.
- [x] `make lint` / `make fmt` / `make vet` — clean.
- [x] `helm lint deploy/helm` — clean.
- [ ] e2e (CI `e2e` matrix, Kind + chainsaw): new assertions verify `ImagePullSecretAttached` (SA) and `Created` (Secret) Events surface in `managed-namespace`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>